### PR TITLE
Fix vlan id for trace path result when using Q-in-Q

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,26 @@ Changelog
 #########
 All notable changes to the sdntrace_cp NApp will be documented in this file.
 
+[Unreleased]
+
+Fixed
+=====
+- [Issue 25] Fix tracepath results to display correct vlan id when using Q-in-Q
+
+[2022.1.0] - 2022-02-08
+***********************
+
+Added
+=====
+- Added ``FIND_CIRCUITS_IN_FLOWS`` settings option to enable or disable the feature to trigger the ``find_circuits`` routine
+- Enhanced and standardized setup.py `install_requires` to install pinned dependencies
+- [Issue 5] Add setup.py and requirements
+
+Fixed
+=====
+- [Issue 6] Fix comparison of endpoints when an endpoint does not provide all necessary fields
+- [Issue 8] Change log level of run_traces results to debug
+
 [UNRELEASED] - Under development
 ********************************
 Added
@@ -23,16 +43,3 @@ Fixed
 Security
 ========
 
-[2022.1.0] - 2022-02-08
-***********************
-
-Added
-=====
-- Added ``FIND_CIRCUITS_IN_FLOWS`` settings option to enable or disable the feature to trigger the ``find_circuits`` routine
-- Enhanced and standardized setup.py `install_requires` to install pinned dependencies
-- [Issue 5] Add setup.py and requirements
-
-Fixed
-=====
-- [Issue 6] Fix comparison of endpoints when an endpoint does not provide all necessary fields
-- [Issue 8] Change log level of run_traces results to debug

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ class Main(KytosNApp):
                                'time': str(datetime.now()),
                                'type': trace_type}}
             if 'vlan_vid' in entries:
-                trace_step['in'].update({'vlan': entries['vlan_vid'][0]})
+                trace_step['in'].update({'vlan': entries['vlan_vid'][-1]})
             switch = self.controller.get_switch_by_dpid(entries['dpid'])
             result = self.trace_step(switch, entries)
             if result:


### PR DESCRIPTION
Fixes #25 

### Description of the change

This PR will fix the result of a trace path when using Q-in-Q in an EVC. Basically, tracepath results were reporting the ingress VLAN as being the first item of the entries on each trace step. However, when using Q-in-Q, that parameter will contain a list of VLANs throughout the process. Reporting only the last item of the VLAN list guarantee we are describing the actual traffic behavior.

Some tests were executed to make sure the change didn't break the results of a tracepath:

```
# mn --topo linear,4 --controller=remote,ip=127.0.0.1
# curl  -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc -d '{"name": "my evc 400", "dynamic_backup_path": true, "enabled": true, "uni_a": {"tag": {"value": 400, "tag_type": 1}, "interface_id": "00:00:00:00:00:00:00:01:1"}, "uni_z": {"tag": {"value": 400, "tag_type": 1}, "interface_id": "00:00:00:00:00:00:00:04:1"}}'

# curl -s http://localhost:8181/api/amlight/sdntrace_cp/trace -X PUT -H 'Content-type: application/json' -d '{"trace": {"switch": {"dpid": "00:00:00:00:00:00:00:01", "in_port": 1}, "eth": {"dl_type": 33024, "dl_vlan": 400}}}' | jq -r
{
  "result": [
    {
      "dpid": "00:00:00:00:00:00:00:01",
      "port": 1,
      "time": "2022-05-17 14:33:03.762700",
      "type": "starting",
      "vlan": 400
    },
    {
      "dpid": "00:00:00:00:00:00:00:02",
      "port": 2,
      "time": "2022-05-17 14:33:03.762812",
      "type": "trace",
      "vlan": 834
    },
    {
      "dpid": "00:00:00:00:00:00:00:03",
      "port": 2,
      "time": "2022-05-17 14:33:03.762862",
      "type": "trace",
      "vlan": 2711
    },
    {
      "dpid": "00:00:00:00:00:00:00:04",
      "port": 2,
      "time": "2022-05-17 14:33:03.762898",
      "type": "trace",
      "vlan": 2734
    }
  ]
}
```