### PR TITLE
[Release][Fix] Shallow copy on sdntrace_cp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,14 @@ Fixed
 Security
 ========
 
+[2022.2.1] - 2022-08-15
+***********************
+
+Fixed
+=====
+- Made a shallow copy when iterating on shared data structure to avoid RuntimeError size changed
+
+
 [2022.2.0] - 2022-08-08
 ***********************
 

--- a/automate.py
+++ b/automate.py
@@ -27,7 +27,7 @@ class Automate:
         all_flows = {}
         circuits = []
 
-        for switch in self._tracer.controller.switches.values():
+        for switch in self._tracer.controller.switches.copy().values():
             all_flows[switch] = []
             if switch.ofp_version == '0x01':
                 controller_port = Port10.OFPP_CONTROLLER

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "sdntrace_cp",
   "description": "Run tracepaths on OpenFlow in the Control Plane",
-  "version": "2022.2.0",
+  "version": "2022.2.1",
   "napp_dependencies": ["amlight/flow_stats", "amlight/scheduler"],
   "license": "MIT",
   "tags": [],

--- a/tests/unit/test_automate.py
+++ b/tests/unit/test_automate.py
@@ -452,6 +452,7 @@ class TestAutomate(TestCase):
             get_switch_mock("00:00:00:00:00:00:00:03", 0x04),
             get_switch_mock("00:00:00:00:00:00:00:04", 0x04),
         ]
+        switches_dict = {}
         for switch in switches:
             flow = MagicMock()
             in_port = MagicMock()
@@ -463,10 +464,9 @@ class TestAutomate(TestCase):
             flow.actions = [action]
             flows = [flow]
             switch.generic_flows = flows
+            switches_dict[switch.id] = switch
 
-        automate._tracer.controller.switches.copy.values.return_value = (
-            switches
-        )
+        automate._tracer.controller.switches = switches_dict
 
         automate.find_circuits()
 

--- a/tests/unit/test_automate.py
+++ b/tests/unit/test_automate.py
@@ -464,7 +464,9 @@ class TestAutomate(TestCase):
             flows = [flow]
             switch.generic_flows = flows
 
-        automate._tracer.controller.switches.values.return_value = switches
+        automate._tracer.controller.switches.copy.values.return_value = (
+            switches
+        )
 
         automate.find_circuits()
 


### PR DESCRIPTION
Fixes #33 

- Shallow copy on sdntrace_cp to avoid RuntimeError size changed
- Bumped 2022.2.1
- Updated changelog.rst