### PR TITLE
Solving issue on responses of PUT /api/amlight/sdntrace_cp/trace

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -104,7 +104,7 @@ paths:
                           example: "2022-01-25 13:44:52.387021"
                         type:
                           type: string
-                          description: Type of the step. May be "starting", "trace", "last" or "loop".
+                          description: Type of the step. May be "starting" or "trace".
                           example: "trace"
                         vlan:
                           type: integer

--- a/openapi.yml
+++ b/openapi.yml
@@ -86,12 +86,30 @@ paths:
                 type: object
                 properties:
                   result:
-                    type: object
-                    properties:
-                      trace_id:
-                        type: integer
-                        description: ID of the trace executed
-                        example: 30001
+                    type: array 
+                    items:
+                      type: object
+                      properties:
+                        dpid:
+                          type: string
+                          description: Switch datapath ID 
+                          example: 00:00:00:00:00:00:00:01
+                        port:
+                          type: integer
+                          description: Incoming port in the switch
+                          example: 1
+                        time:
+                          type: string
+                          description: Start time in the first switch
+                          example: "2022-01-25 13:44:52.387021"
+                        type:
+                          type: string
+                          description: Type of the step. May be "starting", "trace", "last" or "loop".
+                          example: "trace"
+                        vlan:
+                          type: integer
+                          description: VLAN ID
+                          example: 100
   /api/amlight/sdntrace_cp/trace/{trace_id}:
     get:
       summary: Get the result of a trace

--- a/openapi.yml
+++ b/openapi.yml
@@ -89,6 +89,11 @@ paths:
                     type: array 
                     items:
                       type: object
+                      required:
+                        - dpid
+                        - port
+                        - time
+                        - type
                       properties:
                         dpid:
                           type: string
@@ -100,7 +105,7 @@ paths:
                           example: 1
                         time:
                           type: string
-                          description: Start time in the first switch
+                          description: Date time when the iteration was computed
                           example: "2022-01-25 13:44:52.387021"
                         type:
                           type: string


### PR DESCRIPTION
Fixes #18 

The documentation of PUT /api/amlight/sdntrace_cp/trace endpoint indicated a different structure than expected.
Now I have modified the openapi.yml file to specify the correct structure.
