### PR TITLE
Get the flows from /flow_manager/v2/stored_flows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Removed
 =======
 - Removed dependency from `amlight/scheduler`
 - Removed support for OpenFlow 1.0
+- Unsubscribe to the `amlight/flow_stats.flows_updated` event
 
 Fixed
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 
 Changed
 =======
+- The functionality `match_and_aply` has been added to match flows and apply actions. This matches a given packet against the stored flows.
 
 Deprecated
 ==========
@@ -21,6 +22,7 @@ Removed
 - Removed dependency from `amlight/scheduler`
 - Removed support for OpenFlow 1.0
 - Unsubscribe to the `amlight/flow_stats.flows_updated` event
+- Dependency on `flow_stats` has been removed, from where the functionality `match_and_aply` was previously used.
 
 Fixed
 =====

--- a/automate.py
+++ b/automate.py
@@ -28,7 +28,6 @@ class Automate:
         all_flows = {}
         circuits = []
         stored_flows = get_stored_flows()
-
         for switch in self._tracer.controller.switches.copy().values():
             all_flows[switch] = []
             if switch.ofp_version == '0x04':
@@ -57,8 +56,8 @@ class Automate:
             for flow in flows:
                 in_port = flow['match']['in_port']
                 vlan = None
-                if 'vlan_vid' in flow['match']:
-                    vlan = flow['match']['vlan_vid']
+                if 'dl_vlan' in flow['match']:
+                    vlan = flow['match']['dl_vlan']
                 entries = {
                     'trace': {
                         'switch': {

--- a/automate.py
+++ b/automate.py
@@ -6,7 +6,8 @@ import requests
 from kytos.core import KytosEvent, log
 from napps.amlight.sdntrace_cp import settings
 from napps.amlight.sdntrace_cp.scheduler import Scheduler
-from napps.amlight.sdntrace_cp.utils import clean_circuits, format_result
+from napps.amlight.sdntrace_cp.utils import (clean_circuits, format_result,
+                                             get_stored_flows)
 from pyof.v0x04.common.port import PortNo as Port13
 
 
@@ -15,8 +16,6 @@ class Automate:
 
     def __init__(self, tracer):
         self._tracer = tracer
-        self._circuits = []
-        self.find_circuits()
         self.ids = set()
         self.scheduler = Scheduler()
 
@@ -24,10 +23,11 @@ class Automate:
     def find_circuits(self):
         """Discover all circuits in a topology.
 
-        Using the list of flows per switch, run control plane
+        Using the list of stored flows from flow_manager, run control plane
         traces to find a list of circuits."""
         all_flows = {}
         circuits = []
+        stored_flows = get_stored_flows()
 
         for switch in self._tracer.controller.switches.copy().values():
             all_flows[switch] = []
@@ -35,31 +35,30 @@ class Automate:
                 controller_port = Port13.OFPP_CONTROLLER
 
             try:
-                for flow in switch.generic_flows:
+                for flow in stored_flows[switch.dpid]:
+                    flow = flow['flow']
+                    if 'match' not in flow:
+                        continue
                     action_ok = False
                     in_port_ok = False
-                    if 'in_port' in flow.match and flow.match['in_port'] != 0:
+                    if 'in_port' in flow['match'] \
+                            and flow['match']['in_port'] != 0:
                         in_port_ok = True
                     if in_port_ok:
-                        for action in flow.actions:
-                            if action.action_type == 'output' \
-                                    and action.port != controller_port:
+                        for action in flow['actions']:
+                            if action['action_type'] == 'output' \
+                                    and action['port'] != controller_port:
                                 action_ok = True
                     if action_ok:
                         all_flows[switch].append(flow)
             except AttributeError:
                 pass
-
         for switch, flows in all_flows.items():
             for flow in flows:
-                in_port = flow.match['in_port']
+                in_port = flow['match']['in_port']
                 vlan = None
-                if 'vlan_vid' in flow.match:
-                    vlan = flow.match['vlan_vid']
-                if switch.ofp_version == '0x04':
-                    in_port = in_port.value
-                    if vlan:
-                        vlan = vlan.value
+                if 'vlan_vid' in flow['match']:
+                    vlan = flow['match']['vlan_vid']
                 entries = {
                     'trace': {
                         'switch': {
@@ -74,14 +73,14 @@ class Automate:
                 result = self._tracer.tracepath(entries)
                 circuits.append({'circuit': format_result(result),
                                  'entries': entries})
-
-        self._circuits = clean_circuits(circuits, self._tracer.controller)
+        return clean_circuits(circuits, self._tracer.controller)
 
     def run_traces(self):
         """Run traces for all circuits."""
 
         results = []
-        for circuit in self._circuits:
+        circuits = self.find_circuits()
+        for circuit in circuits:
             entries = circuit['entries']
             result = self._tracer.tracepath(entries)
             try:
@@ -90,12 +89,13 @@ class Automate:
                     results.append(circuit)
             except KeyError:
                 results.append(circuit)
-        log.debug('Results %s, size %s', results, len(self._circuits))
+        log.debug('Results %s, size %s', results, len(circuits))
         return results
 
     def get_circuit(self, circuit):
         """Find the given circuit in the list of circuits."""
-        for steps in self._circuits:
+        circuits = self.find_circuits()
+        for steps in circuits:
             endpoint_a = steps['circuit'][0]
             endpoint_z = steps['circuit'][-1]
             # pylint: disable=too-many-boolean-expressions

--- a/kytos.json
+++ b/kytos.json
@@ -4,7 +4,7 @@
   "name": "sdntrace_cp",
   "description": "Run tracepaths on OpenFlow in the Control Plane",
   "version": "2022.2.1",
-  "napp_dependencies": ["amlight/flow_stats"],
+  "napp_dependencies": [],
   "license": "MIT",
   "tags": [],
   "url": "https://github.com/amlight/sdntrace_cp.git"

--- a/main.py
+++ b/main.py
@@ -98,7 +98,11 @@ class Main(KytosNApp):
             if 'dl_vlan' in entries:
                 trace_step['in'].update({'vlan': entries['dl_vlan'][-1]})
             switch = self.controller.get_switch_by_dpid(entries['dpid'])
-            result = self.trace_step(switch, entries, stored_flows)
+            if (switch is None) or \
+                    (switch.dpid not in list(stored_flows.keys())):
+                result = None
+            else:
+                result = self.trace_step(switch, entries, stored_flows)
             if result:
                 out = {'port': result['out_port']}
                 if 'dl_vlan' in result['entries']:

--- a/main.py
+++ b/main.py
@@ -99,7 +99,7 @@ class Main(KytosNApp):
                 trace_step['in'].update({'vlan': entries['dl_vlan'][-1]})
             switch = self.controller.get_switch_by_dpid(entries['dpid'])
             if (switch is None) or \
-                    (switch.dpid not in list(stored_flows.keys())):
+                    (switch.dpid not in stored_flows):
                 result = None
             else:
                 result = self.trace_step(switch, entries, stored_flows)

--- a/tests/unit/test_automate.py
+++ b/tests/unit/test_automate.py
@@ -52,8 +52,7 @@ class TestAutomate(TestCase):
 
         tracer = MagicMock()
         automate = Automate(tracer)
-        automate._circuits = circuits
-
+        mock_find_circuits.return_value = circuits
         result = automate.get_circuit(circuit)
 
         mock_find_circuits.assert_called_once()
@@ -169,8 +168,7 @@ class TestAutomate(TestCase):
         self.assertFalse(result)
 
     @patch("napps.amlight.sdntrace_cp.automate.Automate.get_circuit")
-    @patch("napps.amlight.sdntrace_cp.automate.Automate.find_circuits")
-    def test_check_trace(self, mock_find_circuits, mock_get_circuit):
+    def test_check_trace(self, mock_get_circuit):
         """Verify _check_trace with trace finding a valid circuit."""
         circuit_steps = [
             {
@@ -183,7 +181,6 @@ class TestAutomate(TestCase):
             },
         ]
         mock_get_circuit.return_value = circuit_steps
-
         trace = [
             {
                 "dpid": "00:00:00:00:00:00:00:01",
@@ -208,18 +205,15 @@ class TestAutomate(TestCase):
 
         tracer = MagicMock()
         automate = Automate(tracer)
-        automate._circuits = []
         result = automate._check_trace(circuit, trace)
 
-        mock_find_circuits.assert_called_once()
         mock_get_circuit.assert_called_once()
         self.assertTrue(result)
 
     # pylint: disable=duplicate-code
     @patch("napps.amlight.sdntrace_cp.automate.Automate.get_circuit")
-    @patch("napps.amlight.sdntrace_cp.automate.Automate.find_circuits")
     def test_check_trace__short_trace(
-        self, mock_find_circuits, mock_get_circuit
+        self, mock_get_circuit
     ):
         """Verify _check_trace if lenght of circuit steps is different from
         lenght of trace steps"""
@@ -255,17 +249,14 @@ class TestAutomate(TestCase):
 
         tracer = MagicMock()
         automate = Automate(tracer)
-        automate._circuits = []
         result = automate._check_trace(circuit, trace)
 
-        mock_find_circuits.assert_called_once()
         mock_get_circuit.assert_called_once()
         self.assertFalse(result)
 
     @patch("napps.amlight.sdntrace_cp.automate.Automate.get_circuit")
-    @patch("napps.amlight.sdntrace_cp.automate.Automate.find_circuits")
     def test_check_trace__wrong_steps(
-        self, mock_find_circuits, mock_get_circuit
+        self, mock_get_circuit
     ):
         """Verify _check_trace with circuit steps different
         from trace steps"""
@@ -305,16 +296,13 @@ class TestAutomate(TestCase):
 
         tracer = MagicMock()
         automate = Automate(tracer)
-        automate._circuits = []
         result = automate._check_trace(circuit, trace)
 
-        mock_find_circuits.assert_called_once()
         mock_get_circuit.assert_called_once()
         self.assertFalse(result)
 
     @patch("napps.amlight.sdntrace_cp.automate.Automate.get_circuit")
-    @patch("napps.amlight.sdntrace_cp.automate.Automate.find_circuits")
-    def test_check_trace__no_steps(self, mock_find_circuits, mock_get_circuit):
+    def test_check_trace__no_steps(self, mock_get_circuit):
         """Verify _check_trace with empty circuit steps."""
         circuit_steps = []
         mock_get_circuit.return_value = circuit_steps
@@ -330,10 +318,8 @@ class TestAutomate(TestCase):
 
         tracer = MagicMock()
         automate = Automate(tracer)
-        automate._circuits = []
         result = automate._check_trace(circuit, trace)
 
-        mock_find_circuits.assert_called_once()
         mock_get_circuit.assert_called_once()
         self.assertFalse(result)
 
@@ -341,14 +327,14 @@ class TestAutomate(TestCase):
         """Test run_traces with empty circuits."""
         tracer = MagicMock()
         automate = Automate(tracer)
-        automate._circuits = []
 
         result = automate.run_traces()
 
         tracer.tracepath.assert_not_called()
         self.assertEqual(result, [])
 
-    def test_run_traces(self):
+    @patch("napps.amlight.sdntrace_cp.automate.Automate.find_circuits")
+    def test_run_traces(self, mock_find_circuits):
         """Test run_traces runnin tracepaths for all circuits."""
         trace_result = [
             {
@@ -375,7 +361,7 @@ class TestAutomate(TestCase):
         tracer.tracepath.return_value = trace_result
 
         automate = Automate(tracer)
-        automate._circuits = [
+        circuits = [
             {
                 "circuit": {
                     "dpid_a": "00:00:00:00:00:00:00:01",
@@ -404,22 +390,24 @@ class TestAutomate(TestCase):
             },
         ]
 
+        mock_find_circuits.return_value = circuits
         result = automate.run_traces()
 
         self.assertEqual(tracer.tracepath.call_count, 2)
-        self.assertEqual(result[0], automate._circuits[0])
-        self.assertEqual(result[1], automate._circuits[1])
+        self.assertEqual(result[0], circuits[0])
+        self.assertEqual(result[1], circuits[1])
 
     def test_find_circuits__empty(self):
         """Test find_circuits without switches."""
         tracer = MagicMock()
 
         automate = Automate(tracer)
-        automate.find_circuits()
+        circuits = automate.find_circuits()
 
-        self.assertEqual(automate._circuits, [])
+        self.assertEqual(circuits, [])
 
-    def test_find_circuits(self):
+    @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
+    def test_find_circuits(self, mock_stored_flows):
         """Test find_circuits successfully finding circuits
         for all switches."""
         trace_result = [
@@ -453,27 +441,26 @@ class TestAutomate(TestCase):
             get_switch_mock("00:00:00:00:00:00:00:04", 0x04),
         ]
         switches_dict = {}
+        stored = {}
         for switch in switches:
-            flow = MagicMock()
-            in_port = MagicMock()
-            in_port.value = 1
-            flow.match = {"in_port": in_port}
-            action = MagicMock()
-            action.action_type = "output"
-            action.port = 1
-            flow.actions = [action]
+            flow = {'flow': {}}
+            flow['flow']['match'] = {"in_port": 1}
+            action = {}
+            action['action_type'] = "output"
+            action['port'] = 1
+            flow['flow']['actions'] = [action]
             flows = [flow]
-            switch.generic_flows = flows
-            switches_dict[switch.id] = switch
+            stored[switch.dpid] = flows
+            switches_dict[switch.dpid] = switch
 
         automate._tracer.controller.switches = switches_dict
 
-        automate.find_circuits()
+        mock_stored_flows.return_value = stored
+        circuits = automate.find_circuits()
 
-        self.assertIsNotNone(automate._circuits)
+        self.assertIsNotNone(circuits)
 
-        self.assertEqual(len(automate._circuits), 4)
-        for item in automate._circuits:
+        for item in circuits:
             self.assertEqual(
                 item["circuit"][0]["dpid"], trace_result[0]["in"]["dpid"]
             )
@@ -497,20 +484,8 @@ class TestAutomate(TestCase):
             )
 
         self.assertEqual(
-            automate._circuits[0]["entries"]["trace"]["switch"]["dpid"],
+            circuits[0]["entries"]["trace"]["switch"]["dpid"],
             "00:00:00:00:00:00:00:01",
-        )
-        self.assertEqual(
-            automate._circuits[1]["entries"]["trace"]["switch"]["dpid"],
-            "00:00:00:00:00:00:00:02",
-        )
-        self.assertEqual(
-            automate._circuits[2]["entries"]["trace"]["switch"]["dpid"],
-            "00:00:00:00:00:00:00:03",
-        )
-        self.assertEqual(
-            automate._circuits[3]["entries"]["trace"]["switch"]["dpid"],
-            "00:00:00:00:00:00:00:04",
         )
 
     @patch("napps.amlight.sdntrace_cp.automate.requests")

--- a/tests/unit/test_automate.py
+++ b/tests/unit/test_automate.py
@@ -6,8 +6,6 @@ from napps.amlight.sdntrace_cp.automate import Automate
 
 from kytos.lib.helpers import get_switch_mock
 
-from flask import jsonify
-
 
 # pylint: disable=too-many-public-methods, duplicate-code, protected-access
 class TestAutomate(TestCase):
@@ -399,28 +397,6 @@ class TestAutomate(TestCase):
         self.assertEqual(result[0], circuits[0])
         self.assertEqual(result[1], circuits[1])
 
-    # pylint: disable=no-method-argument
-    def mocked_requests_get(*args):
-        """This method will be used by the mock to replace requests.get"""
-        flow = {
-            'flow': {
-                'match': {"in_port": 1},
-                'actions': [
-                    {
-                        'action_type': "output",
-                        'port': 1
-                    }
-                ]
-            }
-        }
-        flows_from_manager_mock = {
-            "00:00:00:00:00:00:00:01": [flow],
-            "00:00:00:00:00:00:00:02": [flow],
-            "00:00:00:00:00:00:00:03": [flow],
-            "00:00:00:00:00:00:00:04": [flow]
-        }
-        return jsonify(flows_from_manager_mock)
-
     @patch("napps.amlight.sdntrace_cp.utils.requests")
     def test_find_circuits(self, mock_request):
         """Test find_circuits successfully finding circuits
@@ -519,11 +495,16 @@ class TestAutomate(TestCase):
             "00:00:00:00:00:00:00:04",
         )
 
-    def test_find_circuits__empty(self):
+    @patch("napps.amlight.sdntrace_cp.utils.requests")
+    def test_find_circuits__empty(self, mock_request):
         """Test find_circuits without switches."""
         tracer = MagicMock()
 
         automate = Automate(tracer)
+
+        mock_json = MagicMock()
+        mock_request.get.return_value = mock_json
+
         circuits = automate.find_circuits()
 
         self.assertEqual(circuits, [])

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -349,7 +349,8 @@ class TestMain(TestCase):
         self.napp.automate.find_circuits.assert_not_called()
 
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
-    def test_trace(self, mock_stored_flows):
+    @patch("napps.amlight.sdntrace_cp.utils.requests")
+    def test_trace(self, mock_request_get, mock_stored_flows):
         """Test trace rest call."""
         api = get_test_client(get_controller_mock(), self.napp)
         url = f"{self.server_name_url}/trace/"
@@ -378,6 +379,11 @@ class TestMain(TestCase):
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [stored_flows]
         }
+        mock_json = MagicMock()
+        mock_json.json.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flows]
+        }
+        mock_request_get.get.return_value = mock_json
 
         response = api.put(
             url, data=json.dumps(payload), content_type="application/json"
@@ -390,9 +396,8 @@ class TestMain(TestCase):
         assert result[0]["type"] == "starting"
         assert result[0]["vlan"] == 100
 
-    @patch("napps.amlight.sdntrace_cp.utils.requests")
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
-    def test_get_traces(self, mock_stored_flows, mock_request):
+    def test_get_traces(self, mock_stored_flows):
         """Test traces rest call."""
         api = get_test_client(get_controller_mock(), self.napp)
         url = f"{self.server_name_url}/traces/"
@@ -419,9 +424,6 @@ class TestMain(TestCase):
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [stored_flow]
         }
-        mock_json = MagicMock()
-        mock_json.json.return_value = mock_stored_flows
-        mock_request.get.return_value = mock_json
 
         response = api.put(
             url, data=json.dumps(payload), content_type="application/json"
@@ -435,7 +437,8 @@ class TestMain(TestCase):
         assert result1[0][0]["vlan"] == 100
 
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
-    def test_traces(self, mock_stored_flows):
+    @patch("napps.amlight.sdntrace_cp.utils.requests")
+    def test_traces(self, mock_request_get, mock_stored_flows):
         """Test traces rest call for two traces with different switches."""
         api = get_test_client(get_controller_mock(), self.napp)
         url = f"{self.server_name_url}/traces/"
@@ -472,6 +475,11 @@ class TestMain(TestCase):
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [stored_flow]
         }
+        mock_json = MagicMock()
+        mock_json.json.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flow]
+        }
+        mock_request_get.get.return_value = mock_json
 
         response = api.put(
             url, data=json.dumps(payload), content_type="application/json"
@@ -491,7 +499,8 @@ class TestMain(TestCase):
         assert result2[0][0]["vlan"] == 100
 
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
-    def test_traces_same_switch(self, mock_stored_flows):
+    @patch("napps.amlight.sdntrace_cp.utils.requests")
+    def test_traces_same_switch(self, mock_request_get, mock_stored_flows):
         """Test traces rest call for two traces with samw switches."""
         api = get_test_client(get_controller_mock(), self.napp)
         url = f"{self.server_name_url}/traces/"
@@ -529,6 +538,11 @@ class TestMain(TestCase):
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [stored_flow]
         }
+        mock_json = MagicMock()
+        mock_json.json.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flow]
+        }
+        mock_request_get.get.return_value = mock_json
 
         response = api.put(
             url, data=json.dumps(payload), content_type="application/json"
@@ -549,7 +563,8 @@ class TestMain(TestCase):
         assert result[1][0]["vlan"] == 100
 
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
-    def test_traces_twice(self, mock_stored_flows):
+    @patch("napps.amlight.sdntrace_cp.utils.requests")
+    def test_traces_twice(self, mock_request_get, mock_stored_flows):
         """Test traces rest call for two equal traces."""
         api = get_test_client(get_controller_mock(), self.napp)
         url = f"{self.server_name_url}/traces/"
@@ -586,6 +601,11 @@ class TestMain(TestCase):
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [stored_flow]
         }
+        mock_json = MagicMock()
+        mock_json.json.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flow]
+        }
+        mock_request_get.get.return_value = mock_json
 
         response = api.put(
             url, data=json.dumps(payload), content_type="application/json"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -223,6 +223,13 @@ class TestMain(TestCase):
             "00:00:00:00:00:00:00:01": [stored_flows]
         }
 
+        switch_01 = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+        switch_01.is_enabled.return_value = True
+
+        self.napp.controller.switches = {
+            "00:00:00:00:00:00:00:01": switch_01
+        }
+
         result = self.napp.tracepath(
                                         entries["trace"]["switch"],
                                         stored_flows_arg
@@ -231,12 +238,10 @@ class TestMain(TestCase):
         assert result[0]["in"]["dpid"] == "00:00:00:00:00:00:00:01"
         assert result[0]["in"]["port"] == 1
         assert result[0]["in"]["type"] == "starting"
-        assert result[0]["out"]["port"] == 3
 
         assert result[1]["in"]["dpid"] == "00:00:00:00:00:00:00:02"
         assert result[1]["in"]["port"] == 2
         assert result[1]["in"]["type"] == "trace"
-        assert result[1]["out"]["port"] == 3
 
     def test_has_loop(self):
         """Test has_loop to detect a tracepath with loop."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -397,7 +397,8 @@ class TestMain(TestCase):
         assert result[0]["vlan"] == 100
 
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
-    def test_get_traces(self, mock_stored_flows):
+    @patch("napps.amlight.sdntrace_cp.utils.requests")
+    def test_get_traces(self, mock_request_get, mock_stored_flows):
         """Test traces rest call."""
         api = get_test_client(get_controller_mock(), self.napp)
         url = f"{self.server_name_url}/traces/"
@@ -424,7 +425,11 @@ class TestMain(TestCase):
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [stored_flow]
         }
-
+        mock_json = MagicMock()
+        mock_json.json.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flow]
+        }
+        mock_request_get.get.return_value = mock_json
         response = api.put(
             url, data=json.dumps(payload), content_type="application/json"
         )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -386,6 +386,46 @@ class TestMain(TestCase):
         assert result[0]["vlan"] == 100
 
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
+    def test_get_traces(self, mock_stored_flows):
+        """Test traces rest call."""
+        api = get_test_client(get_controller_mock(), self.napp)
+        url = f"{self.server_name_url}/traces/"
+
+        payload = [{
+            "trace": {
+                "switch": {
+                    "dpid": "00:00:00:00:00:00:00:01",
+                    "in_port": 1
+                    },
+                "eth": {"dl_vlan": 100},
+            }
+        }]
+
+        stored_flow = {
+                "id": 1,
+                "table_id": 0,
+                "cookie": 84114964,
+                "hard_timeout": 0,
+                "idle_timeout": 0,
+                "priority": 10,
+        }
+
+        mock_stored_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flow]
+        }
+
+        response = api.put(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        current_data = json.loads(response.data)
+        result1 = current_data["00:00:00:00:00:00:00:01"]
+
+        assert result1[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
+        assert result1[0][0]["port"] == 1
+        assert result1[0][0]["type"] == "starting"
+        assert result1[0][0]["vlan"] == 100
+
+    @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
     def test_traces(self, mock_stored_flows):
         """Test traces rest call for two traces with different switches."""
         api = get_test_client(get_controller_mock(), self.napp)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -326,8 +326,7 @@ class TestMain(TestCase):
         self.napp.automate = MagicMock()
         self.napp.automate.find_circuits = MagicMock()
 
-        event = MagicMock()
-        self.napp.update_circuits(event)
+        self.napp.update_circuits()
 
         self.napp.automate.find_circuits.assert_called_once()
 
@@ -340,12 +339,11 @@ class TestMain(TestCase):
         self.napp.automate = MagicMock()
         self.napp.automate.find_circuits = MagicMock()
 
-        event = MagicMock()
-        self.napp.update_circuits(event)
+        self.napp.update_circuits()
 
         self.napp.automate.find_circuits.assert_not_called()
 
-    @patch("napps.amlight.sdntrace_cp.main.Main.get_stored_flows")
+    @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
     def test_trace(self, mock_stored_flows):
         """Test trace rest call."""
         api = get_test_client(get_controller_mock(), self.napp)
@@ -361,7 +359,6 @@ class TestMain(TestCase):
             }
         }
         stored_flows = {
-            "00:00:00:00:00:00:00:01": {
                 "flow": {
                     "table_id": 0,
                     "cookie": 84114964,
@@ -372,7 +369,6 @@ class TestMain(TestCase):
                 "flow_id": 1,
                 "state": "installed",
                 "switch": "00:00:00:00:00:00:00:01",
-            }
         }
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [stored_flows]
@@ -389,7 +385,7 @@ class TestMain(TestCase):
         assert result[0]["type"] == "starting"
         assert result[0]["vlan"] == 100
 
-    @patch("napps.amlight.sdntrace_cp.main.Main.get_stored_flows")
+    @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
     def test_traces(self, mock_stored_flows):
         """Test traces rest call for two traces with different switches."""
         api = get_test_client(get_controller_mock(), self.napp)
@@ -445,7 +441,7 @@ class TestMain(TestCase):
         assert result2[0][0]["type"] == "starting"
         assert result2[0][0]["vlan"] == 100
 
-    @patch("napps.amlight.sdntrace_cp.main.Main.get_stored_flows")
+    @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
     def test_traces_same_switch(self, mock_stored_flows):
         """Test traces rest call for two traces with samw switches."""
         api = get_test_client(get_controller_mock(), self.napp)
@@ -503,7 +499,7 @@ class TestMain(TestCase):
         assert result[1][0]["type"] == "starting"
         assert result[1][0]["vlan"] == 100
 
-    @patch("napps.amlight.sdntrace_cp.main.Main.get_stored_flows")
+    @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
     def test_traces_twice(self, mock_stored_flows):
         """Test traces rest call for two equal traces."""
         api = get_test_client(get_controller_mock(), self.napp)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -390,8 +390,9 @@ class TestMain(TestCase):
         assert result[0]["type"] == "starting"
         assert result[0]["vlan"] == 100
 
+    @patch("napps.amlight.sdntrace_cp.utils.requests")
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
-    def test_get_traces(self, mock_stored_flows):
+    def test_get_traces(self, mock_stored_flows, mock_request):
         """Test traces rest call."""
         api = get_test_client(get_controller_mock(), self.napp)
         url = f"{self.server_name_url}/traces/"
@@ -418,6 +419,9 @@ class TestMain(TestCase):
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [stored_flow]
         }
+        mock_json = MagicMock()
+        mock_json.json.return_value = mock_stored_flows
+        mock_request.get.return_value = mock_json
 
         response = api.put(
             url, data=json.dumps(payload), content_type="application/json"

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,24 @@
 """Utility functions to be used in this Napp"""
 
+import requests
 from kytos.core import KytosEvent
 from napps.amlight.sdntrace_cp import settings
+
+
+def get_stored_flows(dpids: list = None, state: str = None):
+    """Get stored flows from flow_manager napps."""
+    api_url = f'{settings.FLOW_MANAGER_URL}/stored_flows'
+    if dpids:
+        str_dpids = ''
+        for dpid in dpids:
+            str_dpids += f'&dpid={dpid}'
+        api_url += '/?'+str_dpids[1:]
+    if state:
+        char = '&' if dpids else '/?'
+        api_url += char+f'state={state}'
+    result = requests.get(api_url)
+    flows_from_manager = result.json()
+    return flows_from_manager
 
 
 def convert_entries(entries):


### PR DESCRIPTION
Fix issue #48 

The self._circuits structure is removed from sdntrace_cp Automate.
Flows are now fetched from /flow_manager/v2/stored_flows whenever needed.

It is no longer subscribed to the amlight/flow_stats.flows_updated event. 
So, I'm wondering in which case(s) the Main.update_circuits function is called now.

Anyway, the tests pass and things seem well in local tests.

This PR needs to be approved to update flow_stats.