### PR TITLE
Filter for state=installed by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,6 @@ To install this NApp, first, make sure to have the same venv activated as you ha
 Requirements
 ============
 
-- `amlight/flow_stats <https://github.com/kytos-ng/flow_stats>`_
 - `amlight/scheduler <https://github.com/kytos-ng/scheduler>`_
 
 
@@ -39,9 +38,6 @@ Events
 
 Subscribed
 ----------
-
-- ``amlight/flow_stats.flows_updated``
-
 
 .. TAGs
 

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from kytos.core import KytosEvent
 from napps.amlight.sdntrace_cp import settings
 
 
-def get_stored_flows(dpids: list = None, state: str = None):
+def get_stored_flows(dpids: list = None, state: str = "installed"):
     """Get stored flows from flow_manager napps."""
     api_url = f'{settings.FLOW_MANAGER_URL}/stored_flows'
     if dpids:


### PR DESCRIPTION
Fix #54 

Now on the function get_stored_flows() only installed flows are filtered if no state is specified.

See [change](https://github.com/kytos-ng/sdntrace_cp/blob/65b4248d13fd476aa89dcf09e6de0f98bd4815d4/utils.py#L8)