### PR TITLE
[release] Bumped 2022.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,27 +5,25 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 
 [UNRELEASED] - Under development
 ********************************
+
+[2022.3.0] - 2022-12-15
+***********************
+
 Added
 =====
 - Added ``apscheduler`` library to handle job scheduling
-- Added `PUT /traces` endpoint for bulk requests
+- Added ``PUT /traces`` endpoint for bulk requests
 
 Changed
 =======
-- The functionality `match_and_aply` has been added to match flows and apply actions. This matches a given packet against the stored flows.
-
-Deprecated
-==========
+- The functionality ``match_and_aply`` has been added to match flows and apply actions. This matches a given packet against the stored flows.
 
 Removed
 =======
-- Removed dependency from `amlight/scheduler`
+- Removed dependency from ``amlight/scheduler``
 - Removed support for OpenFlow 1.0
 - Unsubscribe to the `amlight/flow_stats.flows_updated` event
-- Dependency on `flow_stats` has been removed, from where the functionality `match_and_aply` was previously used.
-
-Fixed
-=====
+- Dependency on ``flow_stats`` has been removed, from where the functionality ``match_and_aply`` was previously used.
 
 Security
 ========

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "sdntrace_cp",
   "description": "Run tracepaths on OpenFlow in the Control Plane",
-  "version": "2022.2.1",
+  "version": "2022.3.0",
   "napp_dependencies": [],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
Closes N/A

### Summary

- Bumped 2022.3.0

I'm bumping the version of NApps that can already be bumped, when the time comes, it's just a matter of merging and creating the GitHub release with its `git` tag. 