### PR TITLE
Fix /traces endpoint in bulk mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,10 +72,10 @@ class Main(KytosNApp):
         stored_flows = get_stored_flows()
         results = {}
         list_ready = []
-        for entry in entries:
-            if (entry['dpid'], entry['in_port']) in list_ready:
+        for entry in entries:  
+            if entry in list_ready:
                 continue
-            list_ready.append((entry['dpid'], entry['in_port']))
+            list_ready.append(entry)
             dpid = entry['dpid']
             if dpid not in results:
                 results[dpid] = []

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ class Main(KytosNApp):
         stored_flows = get_stored_flows()
         results = {}
         list_ready = []
-        for entry in entries:  
+        for entry in entries:
             if entry in list_ready:
                 continue
             list_ready.append(entry)


### PR DESCRIPTION
Fix #57 

Now, it is ok. See this example:

Request:

```
[
  {
    "trace": {
      "switch": {
        "dpid": "00:00:00:00:00:00:00:01",
        "in_port": 2
      },
      "eth": {
        "dl_vlan": 100
      }
    }
  },
  {
    "trace": {
      "switch": {
        "dpid": "00:00:00:00:00:00:00:01",
        "in_port": 2
      },
      "eth": {
        "dl_vlan": 101
      }
    }
  }
]
```

Result:

```
{
    "00:00:00:00:00:00:00:01": [
        [
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "port": 2,
                "time": "2022-12-22 16:10:23.329829",
                "type": "starting",
                "vlan": 100
            }
        ],
        [
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "port": 2,
                "time": "2022-12-22 16:10:23.329881",
                "type": "starting",
                "vlan": 101
            }
        ]
    ]
}
```

