### PR TITLE
Adding output port information to help traces for intra switch EVCs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Added
 =====
 - Added ``apscheduler`` library to handle job scheduling
 - Added `PUT /traces` endpoint for bulk requests
+- Added output port information to the trace result (last step) to help validating intra-switch EVCs
 
 Changed
 =======

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -391,10 +391,12 @@ class TestMain(TestCase):
         current_data = json.loads(response.data)
         result = current_data["result"]
 
+        assert len(result) == 1
         assert result[0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert result[0]["port"] == 1
         assert result[0]["type"] == "starting"
         assert result[0]["vlan"] == 100
+        assert result[0]["out"] is None
 
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
     @patch("napps.amlight.sdntrace_cp.utils.requests")
@@ -436,10 +438,13 @@ class TestMain(TestCase):
         current_data = json.loads(response.data)
         result1 = current_data["00:00:00:00:00:00:00:01"]
 
+        assert len(result1) == 1
+        assert len(result1[0]) == 1
         assert result1[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert result1[0][0]["port"] == 1
         assert result1[0][0]["type"] == "starting"
         assert result1[0][0]["vlan"] == 100
+        assert result1[0][0]["out"] is None
 
     @patch("napps.amlight.sdntrace_cp.utils.get_stored_flows")
     @patch("napps.amlight.sdntrace_cp.utils.requests")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -68,7 +68,11 @@ class TestUtils(TestCase):
                 "time": "2022-06-01 01:01:01.100000",
                 "type": "trace",
                 "vlan": 100,
-            }
+            },
+            "out": {
+                "port": 1,
+                "vlan": 123,
+            },
         }
         trace_result.append(trace_step)
 
@@ -90,6 +94,7 @@ class TestUtils(TestCase):
                         "time": "2022-06-01 01:01:01.100000",
                         "type": "trace",
                         "vlan": 100,
+                        "out": {"port": 1, "vlan": 123},
                     },
                 ]
             },
@@ -115,7 +120,11 @@ class TestUtils(TestCase):
                 "time": "2022-06-01 01:01:01.100000",
                 "type": "trace",
                 "vlan": 100,
-            }
+            },
+            "out": {
+                "port": 1,
+                "vlan": 123,
+            },
         }
         trace_result.append(trace_step)
 
@@ -135,6 +144,7 @@ class TestUtils(TestCase):
                         "time": "2022-06-01 01:01:01.100000",
                         "type": "trace",
                         "vlan": 100,
+                        "out": {"port": 1, "vlan": 123},
                     },
                 ]
         )

--- a/utils.py
+++ b/utils.py
@@ -63,6 +63,8 @@ def prepare_list_json(trace_result):
     result = []
     for trace_step in trace_result:
         result.append(trace_step['in'])
+    if result:
+        result[-1]["out"] = trace_result[-1].get("out")
     return result
 
 


### PR DESCRIPTION
This PR will add information to be used for kytos-ng/mef_eline#245

### Description of the change

This PR adds one more piece of information in the control-plane trace output to help consumers identify any missing/misbehaving flow in the last hop of the forwarding process. Before this PR, the correctness of the last hop forwarding rule could not be validated. With this PR, one can compare if the output is how expected.

Before this PR:

1. Sending a trace for intra-switch EVC didn't give any clue about the state of the forwarding rules:
```
# curl -H 'Content-type: application/json' -X PUT http://127.0.0.1:8181/api/amlight/sdntrace_cp/trace -d '{"trace": {"switch": {"dpid": "00:00:00:00:00:00:00:12", "in_port": 1}, "eth": {"dl_type": 33024, "dl_vlan": 201}}}'
{"result":[{"dpid":"00:00:00:00:00:00:00:12","port":1,"time":"2023-01-20 02:16:27.661073","type":"starting","vlan":201}]}
```

2. Sending a trace for an unexisting forwarding rule give pretty much the same result as case 1:
```
# curl -H 'Content-type: application/json' -X PUT http://127.0.0.1:8181/api/amlight/sdntrace_cp/trace -d '{"trace": {"switch": {"dpid": "00:00:00:00:00:00:00:12", "in_port": 1}, "eth": {"dl_type": 33024, "dl_vlan": 999}}}'
{"result":[{"dpid":"00:00:00:00:00:00:00:12","port":1,"time":"2023-01-20 02:16:37.484970","type":"starting","vlan":999}]}
```

With the PR:

1. When the flows exists and are correct (same request above):
```
{"result":[{"dpid":"00:00:00:00:00:00:00:12","out":{"port":51,"vlan":201},"port":1,"time":"2023-01-20 02:17:34.131873","type":"starting","vlan":201}]}
```

2. Non-existing EVC:
```
{"result":[{"dpid":"00:00:00:00:00:00:00:12","out":null,"port":1,"time":"2023-01-20 02:17:42.124861","type":"starting","vlan":999}]}
```

### Local tests

- I've executed unit tests and made sure no regression was presented.
- End-to-end tests were also executed with success (no regression)