### PR TITLE
Fix issue for trace ending in a NNI

### DIFF
--- a/main.py
+++ b/main.py
@@ -123,7 +123,7 @@ class Main(KytosNApp):
                 else:
                     do_trace = False
             else:
-                do_trace = False
+                break
             trace_result.append(trace_step)
         self.traces.update({
             trace_id: trace_result

--- a/tests/unit/test_automate.py
+++ b/tests/unit/test_automate.py
@@ -523,6 +523,7 @@ class TestAutomate(TestCase):
 
         mock_requests.assert_not_called()
 
+    @patch("time.sleep", return_value=None)
     @patch("napps.amlight.sdntrace_cp.automate.requests")
     @patch("napps.amlight.sdntrace_cp.automate.settings")
     @patch("napps.amlight.sdntrace_cp.utils.requests")
@@ -530,7 +531,8 @@ class TestAutomate(TestCase):
                                     self,
                                     mock_request_get,
                                     mock_settings,
-                                    mock_requests
+                                    mock_requests,
+                                    _
                                 ):
         """Test run_important_traces if control plane trace result is
         different from the data plane trace."""
@@ -579,11 +581,12 @@ class TestAutomate(TestCase):
         automate = Automate(tracer)
         automate.run_important_traces()
 
+    @patch("time.sleep", return_value=None)
     @patch("napps.amlight.sdntrace_cp.automate.requests")
     @patch("napps.amlight.sdntrace_cp.automate.settings")
     @patch("napps.amlight.sdntrace_cp.automate.Automate._check_trace")
     def test_run_important_traces__success(
-        self, mock_check_trace, mock_settings, mock_requests
+        self, mock_check_trace, mock_settings, mock_requests, _
     ):
         """Verify run_important_traces if control plane trace result
         is the same result from the data plane trace."""


### PR DESCRIPTION
Fix #53 

### Description of the change

This PR is a simple change to how traces are executed to avoid the last trace_step being added when it shouldn't. In general, the trace should terminate in the switch with the last flows matching the traced traffic. The way Sdntrace_cp was working before this PR could lead to a final step being added incorrectly.

Some unit tests had to be updated to reflect this new scenario because they were incorrectly processed before, meaning: unit tests were passing just because the entries were added even when the tracing step returned null. With the changes, tests are executed according to the application behavior.

I've also taken this opportunity to refactor some unit tests and avoid code duplication, as well as slightly improve coverage.

### Local tests

- Unit tests: PASSED

- End-to-end tests:
```
+ python3 -m pytest tests/test_e2e_10_mef_eline.py tests/test_e2e_11_mef_eline.py tests/test_e2e_12_mef_eline.py tests/test_e2e_13_mef_eline.py tests/test_e2e_14_mef_eline.py tests/test_e2e_15_mef_eline.py tests/test_e2e_40_sdntrace.py --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0
collected 92 items

tests/test_e2e_10_mef_eline.py ..........ss.....x.....x.....             [ 31%]
tests/test_e2e_11_mef_eline.py .....                                     [ 36%]
tests/test_e2e_12_mef_eline.py .....xx.                                  [ 45%]
tests/test_e2e_13_mef_eline.py .....xxXx......xxXx.XXxX.xxxx..x......... [ 90%]
...                                                                      [ 93%]
tests/test_e2e_14_mef_eline.py x                                         [ 94%]
tests/test_e2e_15_mef_eline.py .                                         [ 95%]
tests/test_e2e_40_sdntrace.py ....                                     [100%]
======= 68 passed, 2 skipped, 17 xfailed, 5 xpassed, 430 warnings in 4174.07s (1:09:34) ======
```

- Manual tests: new tests were executed considering the scenario described in Issue #53 and the results are successful now:
```
# created an EVC between JAX2 and AL2
# curl -s http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/862cff16a77c46 | jq -r
{
  "active": true,
  "dynamic_backup_path": true,
  "name": "test sdntrace vlan 99",
...
  "uni_a": {
    "interface_id": "00:00:00:00:00:00:00:22:61",
    "tag": {
      "tag_type": 1,
      "value": 99
    }
  },
  "uni_z": {
    "interface_id": "00:00:00:00:00:00:00:15:54",
    "tag": {
      "tag_type": 1,
      "value": 99
    }
  },
  "updated_at": "2023-01-23T15:03:46"
}

# running trace
# curl -H 'Content-type: application/json' -X PUT http://127.0.0.1:8181/api/amlight/sdntrace_cp/trace -d '{"trace": {"switch": {"dpid": "00:00:00:00:00:00:00:22", "in_port": 61}, "eth": {"dl_type": 33024, "dl_vlan": 99}}}'| jq -r
{
  "result": [
    {
      "dpid": "00:00:00:00:00:00:00:22",
      "port": 61,
      "time": "2023-01-23 15:15:44.410828",
      "type": "starting",
      "vlan": 99
    },
    {
      "dpid": "00:00:00:00:00:00:00:19",
      "port": 15,
      "time": "2023-01-23 15:15:44.410957",
      "type": "trace",
      "vlan": 4
    },
    {
      "dpid": "00:00:00:00:00:00:00:12",
      "port": 12,
      "time": "2023-01-23 15:15:44.411026",
      "type": "trace",
      "vlan": 4
    },
    {
      "dpid": "00:00:00:00:00:00:00:15",
      "out": {
        "port": 54,
        "vlan": 99
      },
      "port": 4,
      "time": "2023-01-23 15:15:44.411149",
      "type": "trace",
      "vlan": 4
    }
  ]
}
```