### PR TITLE
fix: Validate payload for PUT /trace and /traces

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,8 +58,11 @@ class Main(KytosNApp):
     @rest('/trace', methods=['PUT'])
     def trace(self):
         """Trace a path."""
+        result = []
         entries = request.get_json()
         entries = convert_entries(entries)
+        if not entries:
+            return "Bad request", 400
         stored_flows = get_stored_flows()
         result = self.tracepath(entries, stored_flows)
         return jsonify(prepare_json(result))
@@ -123,7 +126,7 @@ class Main(KytosNApp):
                 else:
                     do_trace = False
             else:
-                break
+                do_trace = False
             trace_result.append(trace_step)
         self.traces.update({
             trace_id: trace_result

--- a/openapi.yml
+++ b/openapi.yml
@@ -115,6 +115,13 @@ paths:
                           type: integer
                           description: VLAN ID
                           example: 100
+        400:
+          description: "Parameter 'dpid' and/or 'in_port' is missing"
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Bad request
   /api/amlight/sdntrace_cp/trace/{trace_id}:
     get:
       summary: Get the result of a trace

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -393,6 +393,47 @@ class TestMain(TestCase):
         assert result[0]["out"] == {"port": 2, "vlan": 200}
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
+    def test_trace_missing_parameter(self, mock_stored_flows):
+        """Test trace rest call with a missing parameter."""
+        api = get_test_client(get_controller_mock(), self.napp)
+        url = f"{self.server_name_url}/trace/"
+
+        payload = {
+            "trace": {
+                "switch": {
+                    "in_port": 1
+                    },
+                "eth": {"dl_vlan": 100},
+            }
+        }
+        stored_flows = {
+                "flow": {
+                    "table_id": 0,
+                    "cookie": 84114964,
+                    "hard_timeout": 0,
+                    "idle_timeout": 0,
+                    "priority": 10,
+                    "match": {"dl_vlan": 100, "in_port": 1},
+                    "actions": [
+                        {"action_type": "push_vlan"},
+                        {"action_type": "set_vlan", "vlan_id": 200},
+                        {"action_type": "output", "port": 2}
+                    ],
+                },
+                "flow_id": 1,
+                "state": "installed",
+                "switch": "00:00:00:00:00:00:00:01",
+        }
+        mock_stored_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flows]
+        }
+
+        response = api.put(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        assert response.data == b"Bad request"
+
+    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     def test_get_traces(self, mock_stored_flows):
         """Test traces rest call."""
         api = get_test_client(get_controller_mock(), self.napp)
@@ -504,6 +545,63 @@ class TestMain(TestCase):
         assert result2[0][0]["type"] == "starting"
         assert result2[0][0]["vlan"] == 100
         assert result2[0][0]["out"] == {"port": 2, "vlan": 100}
+
+    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
+    def test_traces_missing_parameter(self, mock_stored_flows):
+        """Test traces rest call with a missing parameter."""
+        api = get_test_client(get_controller_mock(), self.napp)
+        url = f"{self.server_name_url}/traces/"
+
+        payload = [
+            {
+                "trace": {
+                    "switch": {
+                        "dpid": "00:00:00:00:00:00:00:01",
+                        "in_port": 1
+                        },
+                    "eth": {"dl_vlan": 100},
+                }
+            },
+            {
+                "trace": {
+                    "switch": {
+                        "dpid": "00:00:00:00:00:00:00:01"
+                        },
+                    "eth": {"dl_vlan": 100},
+                }
+            },
+            {
+                "trace": {
+                    "switch": {
+                        "in_port": 1
+                        },
+                    "eth": {"dl_vlan": 100},
+                }
+            }
+        ]
+
+        stored_flow = {
+            "id": 1,
+            "flow": {
+                "table_id": 0,
+                "cookie": 84114964,
+                "hard_timeout": 0,
+                "idle_timeout": 0,
+                "priority": 10,
+                "match": {"dl_vlan": 100, "in_port": 1},
+                "actions": [{"action_type": "output", "port": 2}],
+            }
+        }
+
+        mock_stored_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flow],
+        }
+
+        response = api.put(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        current_data = json.loads(response.data)
+        assert len(current_data) == 1
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     def test_traces_same_switch(self, mock_stored_flows):

--- a/utils.py
+++ b/utils.py
@@ -34,6 +34,8 @@ def convert_entries(entries):
             new_entries[field] = value
     if 'dl_vlan' in new_entries:
         new_entries['dl_vlan'] = [new_entries['dl_vlan']]
+    if ('dpid' not in new_entries) or ('in_port' not in new_entries):
+        new_entries = {}
     return new_entries
 
 
@@ -43,7 +45,12 @@ def convert_list_entries(entries):
     :param entries: list(dict)
     :return: list(plain dict)
     """
-    return [convert_entries(entry) for entry in entries]
+    new_entries = []
+    for entry in entries:
+        new_entry = convert_entries(entry)
+        if new_entry:
+            new_entries.append(new_entry)
+    return new_entries
 
 
 def find_endpoint(switch, port):


### PR DESCRIPTION
Closes #63 

### Summary

This PR validates the presence of the 'dpid' and 'in_port' parameters in the payload for PUT /trace and /traces.
In the case of PUT /trace, when one of the parameters is missing the response is "Bad request", 400
In the case of PUT /traces, requests in which one of the parameters is missing are ignored. See the following examples.

1. `Request`
```
[
  {
    "trace": {
      "switch": {
        "in_port": 2
      },
      "eth": {
        "dl_vlan": 100
      }
    }
  },
  {
    "trace": {
      "switch": {
        "dpid": "00:00:00:00:00:00:00:01",
        "in_port": 1
      },
      "eth": {
        "dl_vlan": 100
      }
    }
  }
]
```

`Response`
```
{
    "00:00:00:00:00:00:00:01": [
        [
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "port": 1,
                "time": "2023-02-05 22:00:18.636211",
                "type": "starting",
                "vlan": 100
            },
            {
                "dpid": "00:00:00:00:00:00:00:02",
                "port": 2,
                "time": "2023-02-05 22:00:18.636253",
                "type": "trace",
                "vlan": 3824
            },
            {
                "dpid": "00:00:00:00:00:00:00:03",
                "out": {
                    "port": 1,
                    "vlan": 100
                },
                "port": 2,
                "time": "2023-02-05 22:00:18.636270",
                "type": "trace",
                "vlan": 4001
            }
        ]
    ]
}
```

2. `Request`
```
[
  {
    "trace": {
      "switch": {
        "in_port": 2
      },
      "eth": {
        "dl_vlan": 100
      }
    }
  },
  {
    "trace": {
      "switch": {
        "dpid": "00:00:00:00:00:00:00:01"
      },
      "eth": {
        "dl_vlan": 100
      }
    }
  }
]
```
`Response`
```
{}
```

Note that there are two alternatives to this solution:
1. The "Bad request" response, 400, can be returned if at least one of the requests is incorrect.
2. A list of responses similar to the current solution can be returned, but instead of ignoring bad requests we can return "Bad request", 400 for those cases.

### Local Tests

Two new unittests have been added to validate the case where 'dpid' or 'in_port' is missing in the payload: `test_trace_missing_parameter` and `test_traces_missing_parameter`.

All tests pass.