### PR TITLE
fix: Check the `actions` field in flows when running a trace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,16 +6,16 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
-[2022.3.1] - 2023-02-28
+Fixed
+=====
+- Check the ``actions`` field in flows when running Sdntrace to avoid KeyError.
+
+[2022.3.1] - 2023-02-27
 ***********************
 
 Changed
 =======
 - ``PUT /traces`` will return the results in order, without aggregating them by `dpid`. Also, failed traces are not omitted.
-
-Fixed
-=====
-- Check the ``actions`` field in flows when running Sdntrace to avoid KeyError
 
 [2022.3.0] - 2022-12-15
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,16 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
-[2022.3.1] - 2023-02-24
+[2022.3.1] - 2023-02-28
 ***********************
 
 Changed
 =======
 - ``PUT /traces`` will return the results in order, without aggregating them by `dpid`. Also, failed traces are not omitted.
+
+Fixed
+=====
+- Check the ``actions`` field in flows when running Sdntrace to avoid KeyError
 
 [2022.3.0] - 2022-12-15
 ***********************

--- a/main.py
+++ b/main.py
@@ -58,8 +58,11 @@ class Main(KytosNApp):
     @rest('/trace', methods=['PUT'])
     def trace(self):
         """Trace a path."""
+        result = []
         entries = request.get_json()
         entries = convert_entries(entries)
+        if not entries:
+            return "Bad request", 400
         stored_flows = get_stored_flows()
         result = self.tracepath(entries, stored_flows)
         return jsonify(prepare_json(result))
@@ -123,7 +126,7 @@ class Main(KytosNApp):
                 else:
                     do_trace = False
             else:
-                break
+                do_trace = False
             trace_result.append(trace_step)
         self.traces.update({
             trace_id: trace_result

--- a/main.py
+++ b/main.py
@@ -231,11 +231,10 @@ class Main(KytosNApp):
         if a match flow is found, apply its actions."""
         flow = self.match_flows(switch, args, stored_flows, False)
         port = None
-        actions = None
+        actions = []
         # pylint: disable=too-many-nested-blocks
         if not flow or switch.ofp_version != '0x04':
             return flow, args, port
-        actions = []
         if 'actions' in flow['flow']:
             actions = flow['flow']['actions']
         for action in actions:

--- a/main.py
+++ b/main.py
@@ -235,7 +235,9 @@ class Main(KytosNApp):
         # pylint: disable=too-many-nested-blocks
         if not flow or switch.ofp_version != '0x04':
             return flow, args, port
-        actions = flow['flow']['actions']
+        actions = []
+        if 'actions' in flow['flow']:
+            actions = flow['flow']['actions']
         for action in actions:
             action_type = action['action_type']
             if action_type == 'output':

--- a/openapi.yml
+++ b/openapi.yml
@@ -115,6 +115,13 @@ paths:
                           type: integer
                           description: VLAN ID
                           example: 100
+        400:
+          description: "Parameter 'dpid' and/or 'in_port' is missing"
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Bad request
   /api/amlight/sdntrace_cp/trace/{trace_id}:
     get:
       summary: Get the result of a trace

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -393,6 +393,47 @@ class TestMain(TestCase):
         assert result[0]["out"] == {"port": 2, "vlan": 200}
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
+    def test_trace_missing_parameter(self, mock_stored_flows):
+        """Test trace rest call with a missing parameter."""
+        api = get_test_client(get_controller_mock(), self.napp)
+        url = f"{self.server_name_url}/trace/"
+
+        payload = {
+            "trace": {
+                "switch": {
+                    "in_port": 1
+                    },
+                "eth": {"dl_vlan": 100},
+            }
+        }
+        stored_flows = {
+                "flow": {
+                    "table_id": 0,
+                    "cookie": 84114964,
+                    "hard_timeout": 0,
+                    "idle_timeout": 0,
+                    "priority": 10,
+                    "match": {"dl_vlan": 100, "in_port": 1},
+                    "actions": [
+                        {"action_type": "push_vlan"},
+                        {"action_type": "set_vlan", "vlan_id": 200},
+                        {"action_type": "output", "port": 2}
+                    ],
+                },
+                "flow_id": 1,
+                "state": "installed",
+                "switch": "00:00:00:00:00:00:00:01",
+        }
+        mock_stored_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flows]
+        }
+
+        response = api.put(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        assert response.data == b"Bad request"
+
+    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     def test_get_traces(self, mock_stored_flows):
         """Test traces rest call."""
         api = get_test_client(get_controller_mock(), self.napp)
@@ -504,6 +545,63 @@ class TestMain(TestCase):
         assert result2[0][0]["type"] == "starting"
         assert result2[0][0]["vlan"] == 100
         assert result2[0][0]["out"] == {"port": 2, "vlan": 100}
+
+    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
+    def test_traces_missing_parameter(self, mock_stored_flows):
+        """Test traces rest call with a missing parameter."""
+        api = get_test_client(get_controller_mock(), self.napp)
+        url = f"{self.server_name_url}/traces/"
+
+        payload = [
+            {
+                "trace": {
+                    "switch": {
+                        "dpid": "00:00:00:00:00:00:00:01",
+                        "in_port": 1
+                        },
+                    "eth": {"dl_vlan": 100},
+                }
+            },
+            {
+                "trace": {
+                    "switch": {
+                        "dpid": "00:00:00:00:00:00:00:01"
+                        },
+                    "eth": {"dl_vlan": 100},
+                }
+            },
+            {
+                "trace": {
+                    "switch": {
+                        "in_port": 1
+                        },
+                    "eth": {"dl_vlan": 100},
+                }
+            }
+        ]
+
+        stored_flow = {
+            "id": 1,
+            "flow": {
+                "table_id": 0,
+                "cookie": 84114964,
+                "hard_timeout": 0,
+                "idle_timeout": 0,
+                "priority": 10,
+                "match": {"dl_vlan": 100, "in_port": 1},
+                "actions": [{"action_type": "output", "port": 2}],
+            }
+        }
+
+        mock_stored_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flow],
+        }
+
+        response = api.put(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        current_data = json.loads(response.data)
+        assert len(current_data) == 1
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     def test_traces_same_switch(self, mock_stored_flows):

--- a/utils.py
+++ b/utils.py
@@ -34,6 +34,8 @@ def convert_entries(entries):
             new_entries[field] = value
     if 'dl_vlan' in new_entries:
         new_entries['dl_vlan'] = [new_entries['dl_vlan']]
+    if ('dpid' not in new_entries) or ('in_port' not in new_entries):
+        new_entries = {}
     return new_entries
 
 
@@ -43,7 +45,12 @@ def convert_list_entries(entries):
     :param entries: list(dict)
     :return: list(plain dict)
     """
-    return [convert_entries(entry) for entry in entries]
+    new_entries = []
+    for entry in entries:
+        new_entry = convert_entries(entry)
+        if new_entry:
+            new_entries.append(new_entry)
+    return new_entries
 
 
 def find_endpoint(switch, port):


### PR DESCRIPTION
Closes #61 

### Summary

Now, it is checked if `actions` is a field of the flow [See link](https://github.com/kytos-ng/sdntrace_cp/blob/86b466560b449b20028512ad4aa1f632bff8946e/main.py#L238).

### Local Tests

Now, when running Sdntrace in a switch that has a Flow without actions:

Create a flow for drop packets (no actions):

```
curl -X POST -H 'Content-type: application/json' -d '{"flows": [{"priority": 10, "match": {"in_port": 60, "dl_vlan": 777}}]}' http://127.0.0.1:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01
```

Run a trace:

```
curl -H 'Content-type: application/json' -X PUT http://127.0.0.1:8181/api/amlight/sdntrace_cp/trace -d '{"trace": {"switch": {"dpid": "00:00:00:00:00:00:00:01", "in_port": 60}, "eth": {"dl_type": 33024, "dl_vlan": 777}}}
```

Response:

```
{"result":[{"dpid":"00:00:00:00:00:00:00:01","out":null,"port":60,"time":"2023-02-06 13:27:59.390535","type":"starting","vlan":777}]}
```
