### PR TITLE
doc: Specifies required properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 Fixed
 =====
 - Check the ``actions`` field in flows when running Sdntrace to avoid KeyError.
+- In ``PUT /trace`` and ``PUT /traces``, field ``switch``` is defined as required, as well as its parameters ``dpid``` and ``in_port``.
 
 [2022.3.1] - 2023-02-27
 ***********************

--- a/openapi.yml
+++ b/openapi.yml
@@ -19,6 +19,9 @@ paths:
                   properties:
                     switch:
                       type: object
+                      required:
+                        - dpid
+                        - in_port
                       properties:
                         dpid:
                           type: string
@@ -185,6 +188,9 @@ paths:
                     properties:
                       switch:
                         type: object
+                        required:
+                          - dpid
+                          - in_port
                         properties:
                           dpid:
                             type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -16,6 +16,8 @@ paths:
               properties:
                 trace:
                   type: object
+                  required:
+                    - switch
                   properties:
                     switch:
                       type: object
@@ -185,6 +187,8 @@ paths:
                 properties:
                   trace:
                     type: object
+                    required:
+                      - switch
                     properties:
                       switch:
                         type: object


### PR DESCRIPTION
This is for #69 

Specifies properties `dpid` and `in_port` as required into the openapi file.
 
Still need to validate according to the OpenAPI specification, waiting for openapi-core and the validator decorator to be moved to [kytos-ng core](https://github.com/kytos-ng/kytos/issues/261).