### PR TITLE
fix: Return a list of paths with the `PUT /traces` endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,18 +9,9 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 [2022.3.1] - 2023-02-24
 ***********************
 
-Added
-=====
-
 Changed
 =======
 - ``PUT /traces`` will return the results in order, without aggregating them by `dpid`. Also, failed traces are not omitted.
-
-Removed
-=======
-
-Fixed
-=====
 
 [2022.3.0] - 2022-12-15
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,19 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+
+Changed
+=======
+- ``PUT /traces`` will return the results in order, without aggregating them by `dpid`. Also, failed traces are not omitted.
+
+Removed
+=======
+
+Fixed
+=====
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.1] - 2023-02-24
+***********************
+
 Added
 =====
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "sdntrace_cp",
   "description": "Run tracepaths on OpenFlow in the Control Plane",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "napp_dependencies": [],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -115,8 +115,7 @@ class Main(KytosNApp):
                         entries['in_port'] = result['in_port']
                         trace_type = 'trace'
                 else:
-                    if trace_type != 'starting':
-                        trace_step['in']['type'] = 'last'
+                    trace_step['in']['type'] = 'last'
                     do_trace = False
             else:
                 # Incomplete

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from napps.amlight.sdntrace_cp.automate import Automate
 from napps.amlight.sdntrace_cp.utils import (convert_entries,
                                              convert_list_entries,
                                              find_endpoint, get_stored_flows,
-                                             prepare_json, prepare_list_json)
+                                             prepare_json)
 
 
 class Main(KytosNApp):
@@ -70,19 +70,10 @@ class Main(KytosNApp):
         entries = request.get_json()
         entries = convert_list_entries(entries)
         stored_flows = get_stored_flows()
-        results = {}
-        list_ready = []
+        results = []
         for entry in entries:
-            if entry in list_ready:
-                continue
-            list_ready.append(entry)
-            dpid = entry['dpid']
-            result = prepare_list_json(self.tracepath(entry, stored_flows))
-            if result:
-                if dpid not in results:
-                    results[dpid] = []
-                results[dpid].append(result)
-        return jsonify(results)
+            results.append(self.tracepath(entry, stored_flows))
+        return jsonify(prepare_json(results))
 
     def tracepath(self, entries, stored_flows):
         """Trace a path for a packet represented by entries."""

--- a/main.py
+++ b/main.py
@@ -77,10 +77,11 @@ class Main(KytosNApp):
                 continue
             list_ready.append(entry)
             dpid = entry['dpid']
-            if dpid not in results:
-                results[dpid] = []
             result = prepare_list_json(self.tracepath(entry, stored_flows))
-            results[dpid].append(result)
+            if result:
+                if dpid not in results:
+                    results[dpid] = []
+                results[dpid].append(result)
         return jsonify(results)
 
     def tracepath(self, entries, stored_flows):

--- a/openapi.yml
+++ b/openapi.yml
@@ -248,8 +248,8 @@ paths:
               schema:
                 type: object
                 properties:
-                  switch:
-                    type: array
+                  result:
+                    type: array 
                     items:
                       type: array
                       items:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -432,7 +432,7 @@ class TestMain(TestCase):
             url, data=json.dumps(payload), content_type="application/json"
         )
         current_data = json.loads(response.data)
-        result1 = current_data["00:00:00:00:00:00:00:01"]
+        result1 = current_data["result"]
 
         assert len(result1) == 1
         assert len(result1[0]) == 1
@@ -490,142 +490,18 @@ class TestMain(TestCase):
             url, data=json.dumps(payload), content_type="application/json"
         )
         current_data = json.loads(response.data)
-        result1 = current_data["00:00:00:00:00:00:00:01"]
-        result2 = current_data["00:00:00:00:00:00:00:02"]
+        result = current_data["result"]
 
-        assert result1[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
-        assert result1[0][0]["port"] == 1
-        assert result1[0][0]["type"] == "starting"
-        assert result1[0][0]["vlan"] == 100
-        assert result1[0][0]["out"] == {"port": 2, "vlan": 100}
-
-        assert result2[0][0]["dpid"] == "00:00:00:00:00:00:00:02"
-        assert result2[0][0]["port"] == 1
-        assert result2[0][0]["type"] == "starting"
-        assert result2[0][0]["vlan"] == 100
-        assert result2[0][0]["out"] == {"port": 2, "vlan": 100}
-
-    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
-    def test_traces_same_switch(self, mock_stored_flows):
-        """Test traces rest call for two traces with samw switches."""
-        api = get_test_client(get_controller_mock(), self.napp)
-        url = f"{self.server_name_url}/traces/"
-
-        payload = [
-            {
-                "trace": {
-                    "switch": {
-                        "dpid": "00:00:00:00:00:00:00:01",
-                        "in_port": 1
-                    },
-                    "eth": {"dl_vlan": 100},
-                }
-            },
-            {
-                "trace": {
-                    "switch": {
-                        "dpid": "00:00:00:00:00:00:00:01",
-                        "in_port": 2
-                    },
-                    "eth": {"dl_vlan": 100},
-                }
-            }
-        ]
-
-        stored_flow = {
-            "id": 1,
-            "flow": {
-                "table_id": 0,
-                "cookie": 84114964,
-                "hard_timeout": 0,
-                "idle_timeout": 0,
-                "priority": 10,
-                "match": {"dl_vlan": 100},
-                "actions": [{"action_type": "output", "port": 3}],
-            }
-        }
-
-        mock_stored_flows.return_value = {
-            "00:00:00:00:00:00:00:01": [stored_flow]
-        }
-
-        response = api.put(
-            url, data=json.dumps(payload), content_type="application/json"
-        )
-        current_data = json.loads(response.data)
-        result = current_data["00:00:00:00:00:00:00:01"]
-
-        assert len(current_data) == 1
         assert len(result) == 2
-        assert len(result[0]) == 1
-        assert len(result[1]) == 1
-
-        assert result[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
-        assert result[0][0]["port"] == 1
-        assert result[0][0]["type"] == "starting"
-        assert result[0][0]["vlan"] == 100
-        assert result[0][0]["out"] == {"port": 3, "vlan": 100}
-
-        assert result[1][0]["dpid"] == "00:00:00:00:00:00:00:01"
-        assert result[1][0]["port"] == 2
-        assert result[1][0]["type"] == "starting"
-        assert result[1][0]["vlan"] == 100
-        assert result[1][0]["out"] == {"port": 3, "vlan": 100}
-
-    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
-    def test_traces_twice(self, mock_stored_flows):
-        """Test traces rest call for two equal traces."""
-        api = get_test_client(get_controller_mock(), self.napp)
-        url = f"{self.server_name_url}/traces/"
-
-        payload = [
-            {
-                "trace": {
-                    "switch": {
-                        "dpid": "00:00:00:00:00:00:00:01",
-                        "in_port": 1
-                        },
-                    "eth": {"dl_vlan": 100},
-                }
-            },
-            {
-                "trace": {
-                    "switch": {
-                        "dpid": "00:00:00:00:00:00:00:01",
-                        "in_port": 1
-                        },
-                    "eth": {"dl_vlan": 100},
-                }
-            }
-        ]
-        stored_flow = {
-            "id": 1,
-            "flow": {
-                "table_id": 0,
-                "cookie": 84114964,
-                "hard_timeout": 0,
-                "idle_timeout": 0,
-                "priority": 10,
-                "match": {"dl_vlan": 100, "in_port": 1},
-                "actions": [{"action_type": "output", "port": 2}],
-            }
-        }
-
-        mock_stored_flows.return_value = {
-            "00:00:00:00:00:00:00:01": [stored_flow]
-        }
-
-        response = api.put(
-            url, data=json.dumps(payload), content_type="application/json"
-        )
-        current_data = json.loads(response.data)
-        result = current_data["00:00:00:00:00:00:00:01"]
-
-        assert len(current_data) == 1
-        assert len(result) == 1
 
         assert result[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert result[0][0]["port"] == 1
         assert result[0][0]["type"] == "starting"
         assert result[0][0]["vlan"] == 100
         assert result[0][0]["out"] == {"port": 2, "vlan": 100}
+
+        assert result[1][0]["dpid"] == "00:00:00:00:00:00:00:02"
+        assert result[1][0]["port"] == 1
+        assert result[1][0]["type"] == "starting"
+        assert result[1][0]["vlan"] == 100
+        assert result[1][0]["out"] == {"port": 2, "vlan": 100}

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -388,7 +388,7 @@ class TestMain(TestCase):
         assert len(result) == 1
         assert result[0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert result[0]["port"] == 1
-        assert result[0]["type"] == "starting"
+        assert result[0]["type"] == "last"
         assert result[0]["vlan"] == 100
         assert result[0]["out"] == {"port": 2, "vlan": 200}
 
@@ -438,7 +438,7 @@ class TestMain(TestCase):
         assert len(result1[0]) == 1
         assert result1[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert result1[0][0]["port"] == 1
-        assert result1[0][0]["type"] == "starting"
+        assert result1[0][0]["type"] == "last"
         assert result1[0][0]["vlan"] == 100
         assert result1[0][0]["out"] == {"port": 2}
 
@@ -496,12 +496,12 @@ class TestMain(TestCase):
 
         assert result[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert result[0][0]["port"] == 1
-        assert result[0][0]["type"] == "starting"
+        assert result[0][0]["type"] == "last"
         assert result[0][0]["vlan"] == 100
         assert result[0][0]["out"] == {"port": 2, "vlan": 100}
 
         assert result[1][0]["dpid"] == "00:00:00:00:00:00:00:02"
         assert result[1][0]["port"] == 1
-        assert result[1][0]["type"] == "starting"
+        assert result[1][0]["type"] == "last"
         assert result[1][0]["vlan"] == 100
         assert result[1][0]["out"] == {"port": 2, "vlan": 100}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -128,7 +128,7 @@ class TestUtils(TestCase):
         }
         trace_result.append(trace_step)
 
-        result = utils.prepare_list_json(trace_result)
+        result = utils._prepare_json(trace_result)
 
         self.assertEqual(
             result, [

--- a/utils.py
+++ b/utils.py
@@ -58,7 +58,7 @@ def find_endpoint(switch, port):
     return None
 
 
-def prepare_list_json(trace_result):
+def _prepare_json(trace_result):
     """Prepare return list of json for REST call."""
     result = []
     for trace_step in trace_result:
@@ -70,7 +70,13 @@ def prepare_list_json(trace_result):
 
 def prepare_json(trace_result):
     """Prepare return json for REST call."""
-    return {'result': prepare_list_json(trace_result)}
+    result = []
+    if trace_result and isinstance(trace_result[0], list):
+        for trace in trace_result:
+            result.append(_prepare_json(trace))
+    else:
+        result = _prepare_json(trace_result)
+    return {'result': result}
 
 
 def format_result(trace):

--- a/utils.py
+++ b/utils.py
@@ -59,7 +59,7 @@ def find_endpoint(switch, port):
 
 
 def _prepare_json(trace_result):
-    """Prepare return list of json for REST call."""
+    """Auxiliar function to return the json for REST call."""
     result = []
     for trace_step in trace_result:
         result.append(trace_step['in'])


### PR DESCRIPTION
Closes #74 

### Summary

This PR is to ensure that empty lists are not returned with `PUT /traces` to avoid errors.

### Local Tests

For the request:

```
curl -H 'Content-type: application/json' -X PUT http://127.0.0.1:8181/api/amlight/sdntrace_cp/traces -d '[{"trace": {"switch": {"dpid": "00:00:00:00:00:00:00:01", "in_port": 2}, "eth": {"dl_type": 33024, "dl_vlan": 777}}}]'
```

Now:
```{}```
