### PR TITLE
feaure: Add new case of loop when the outgoing interface is the same as the input interface 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 Changed
 =======
 - Update ``tracepath`` to support two new trace types: `loop` and `incomplete`. The `trace` type is now `intermediary`. The `incomplete`` type replaces the empty list that was returned as a response in some cases.
+- Add new case of `loop` when the outgoing interface is the same as the input interface.
 
 Fixed
 =====

--- a/main.py
+++ b/main.py
@@ -135,6 +135,11 @@ class Main(KytosNApp):
     @staticmethod
     def has_loop(trace_step, trace_result):
         """Check if there is a loop in the trace result."""
+        # outgoing interface is the same as the input interface
+        if trace_result and \
+                trace_result[-1]['in']['dpid'] ==  \
+                trace_result[-1]['out']['port']:
+            return True
         for trace in trace_result:
             if trace['in']['dpid'] == trace_step['dpid'] and \
                             trace['in']['port'] == trace_step['port']:

--- a/main.py
+++ b/main.py
@@ -108,6 +108,10 @@ class Main(KytosNApp):
                 trace_step.update({
                     'out': out
                 })
+                if self.trace_step_has_loop(trace_step):
+                    trace_step['in']['type'] = 'loop'
+                    trace_result.append(trace_step)
+                    break
                 if 'dpid' in result:
                     next_step = {'dpid': result['dpid'],
                                  'port': result['in_port']}
@@ -115,7 +119,6 @@ class Main(KytosNApp):
                     entries['dpid'] = result['dpid']
                     entries['in_port'] = result['in_port']
                     if self.has_loop(next_step, trace_result):
-                        # Loop
                         trace_step['in']['type'] = 'loop'
                         do_trace = False
                     else:
@@ -133,13 +136,16 @@ class Main(KytosNApp):
         return trace_result
 
     @staticmethod
-    def has_loop(trace_step, trace_result):
+    def trace_step_has_loop(trace):
         """Check if there is a loop in the trace result."""
         # outgoing interface is the same as the input interface
-        if trace_result and \
-                trace_result[-1]['in']['dpid'] ==  \
-                trace_result[-1]['out']['port']:
+        if trace['in']['port'] == trace['out']['port']:
             return True
+        return False
+
+    @staticmethod
+    def has_loop(trace_step, trace_result):
+        """Check if there is a loop in the trace result."""
         for trace in trace_result:
             if trace['in']['dpid'] == trace_step['dpid'] and \
                             trace['in']['port'] == trace_step['port']:

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ class Main(KytosNApp):
                 trace_step.update({
                     'out': out
                 })
-                if self.trace_step_has_loop(trace_step):
+                if out and self.trace_step_has_loop(trace_step, trace_result):
                     trace_step['in']['type'] = 'loop'
                     trace_result.append(trace_step)
                     break
@@ -136,10 +136,14 @@ class Main(KytosNApp):
         return trace_result
 
     @staticmethod
-    def trace_step_has_loop(trace):
+    def trace_step_has_loop(trace, trace_result):
         """Check if there is a loop in the trace result."""
         # outgoing interface is the same as the input interface
-        if trace['in']['port'] == trace['out']['port']:
+        if not trace_result and trace['in']['port'] == trace['out']['port']:
+            return True
+        if trace_result and \
+                trace_result[0]['in']['dpid'] == trace['in']['dpid'] and \
+                trace_result[0]['in']['port'] == trace['out']['port']:
             return True
         return False
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -579,6 +579,55 @@ class TestMain(TestCase):
         assert result[3][0]["out"] is None
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
+    def test_traces_with_loop(self, mock_stored_flows):
+        """Test traces rest call"""
+        api = get_test_client(get_controller_mock(), self.napp)
+        url = f"{self.server_name_url}/traces/"
+
+        payload = [
+                    {
+                        "trace": {
+                            "switch": {
+                                "dpid": "00:00:00:00:00:00:00:01",
+                                "in_port": 1
+                            },
+                            "eth": {
+                                "dl_vlan": 100
+                            }
+                        }
+                    }
+                ]
+
+        stored_flow = {
+            "id": 1,
+            "flow": {
+                "table_id": 0,
+                "cookie": 84114964,
+                "hard_timeout": 0,
+                "idle_timeout": 0,
+                "priority": 10,
+                "match": {"dl_vlan": 100, "in_port": 1},
+                "actions": [{"action_type": "output", "port": 1}],
+            }
+        }
+
+        mock_stored_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [stored_flow]
+        }
+
+        response = api.put(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        current_data = json.loads(response.data)
+        result = current_data["result"]
+        assert len(result) == 1
+        assert result[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
+        assert result[0][0]["port"] == 1
+        assert result[0][0]["type"] == "loop"
+        assert result[0][0]["vlan"] == 100
+        assert result[0][0]["out"] == {"port": 1, "vlan": 100}
+
+    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     def test_traces_no_action(self, mock_stored_flows):
         """Test traces rest call for two traces with different switches."""
         api = get_test_client(get_controller_mock(), self.napp)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -612,7 +612,7 @@ class TestMain(TestCase):
         }
 
         mock_stored_flows.return_value = {
-            "00:00:00:00:00:00:00:01": [stored_flow]
+            "00:00:00:00:00:00:00:01": [stored_flow],
         }
 
         response = api.put(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -237,6 +237,29 @@ class TestMain(TestCase):
         assert result[1]["in"]["type"] == "intermediary"
         assert result[1]["out"]["port"] == 3
 
+    @patch("napps.amlight.sdntrace_cp.main.Main.trace_step")
+    def test_tracepath_loop(self, mock_trace_step):
+        """Test tracepath with success result."""
+        eth = {"dl_vlan": 100}
+        dpid = {"dpid": "00:00:00:00:00:00:00:01", "in_port": 1}
+        switch = {"switch": dpid, "eth": eth}
+        entries = {"trace": switch}
+        mock_trace_step.return_value = {
+            "dpid": "00:00:00:00:00:00:00:01",
+            "in_port": 1,
+            "out_port": 1,
+            "entries": entries,
+        }
+
+        result = self.napp.tracepath(
+                                        entries["trace"]["switch"],
+                                        {}
+                                    )
+        assert len(result) == 2
+        # input interface = output interface
+        assert result[0]["in"]["type"] == "starting"
+        assert result[1]["in"]["type"] == "loop"
+
     def test_has_loop(self):
         """Test has_loop to detect a tracepath with loop."""
         trace_result = [


### PR DESCRIPTION
Closes #80 

### Summary

Detects a loop when the input and outgoing interfaces match.
Notice that when the trace contains only one step, it will have the `loop`type if the in_port and out_port match.

### Local Tests

Test the same case of the issue.

Response:

```

```

### End-to-End Tests

Progress ... 