### PR TITLE
feature: Support `untagged` and `any` for `vlan`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Support `untagged`` and `any`` on EVCs.
+
 Changed
 =======
 - Update ``tracepath`` to support two new trace types: `loop` and `incomplete`. The `trace` type is now `intermediary`. The `incomplete`` type replaces the empty list that was returned as a response in some cases.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 
 Added
 =====
-- Support `untagged`` and `any`` on EVCs.
+- Support "untagged" and "any" on EVCs.
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from napps.amlight.sdntrace_cp.automate import Automate
 from napps.amlight.sdntrace_cp.utils import (convert_entries,
                                              convert_list_entries,
                                              find_endpoint, get_stored_flows,
-                                             prepare_json)
+                                             map_dl_vlan, prepare_json)
 
 
 class Main(KytosNApp):
@@ -201,6 +201,7 @@ class Main(KytosNApp):
                 return False
             if name == 'dl_vlan':
                 field = args[name][-1]
+                field = map_dl_vlan(field)
             else:
                 field = args[name]
             if name not in ('ipv4_src', 'ipv4_dst', 'ipv6_src', 'ipv6_dst'):

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from napps.amlight.sdntrace_cp.automate import Automate
 from napps.amlight.sdntrace_cp.utils import (convert_entries,
                                              convert_list_entries,
                                              find_endpoint, get_stored_flows,
-                                             map_dl_vlan, prepare_json)
+                                             match_field_dl_vlan, prepare_json)
 
 
 class Main(KytosNApp):
@@ -76,7 +76,8 @@ class Main(KytosNApp):
         results = []
         for entry in entries:
             results.append(self.tracepath(entry, stored_flows))
-        return jsonify(prepare_json(results))
+        temp = prepare_json(results)
+        return jsonify(temp)
 
     def tracepath(self, entries, stored_flows):
         """Trace a path for a packet represented by entries."""
@@ -201,9 +202,10 @@ class Main(KytosNApp):
                 return False
             if name == 'dl_vlan':
                 field = args[name][-1]
-                field = map_dl_vlan(field)
-            else:
-                field = args[name]
+                if not match_field_dl_vlan(field, field_flow):
+                    return False
+                continue
+            field = args[name]
             if name not in ('ipv4_src', 'ipv4_dst', 'ipv6_src', 'ipv6_dst'):
                 if field_flow != field:
                     return False

--- a/main.py
+++ b/main.py
@@ -200,13 +200,11 @@ class Main(KytosNApp):
         for name in flow['flow']['match']:
             field_flow = flow['flow']['match'][name]
             if name == 'dl_vlan':
-                if name not in args:
-                    if field_flow != 0:
-                        return False
-                else:
-                    field = args[name][-1]
-                    if not match_field_dl_vlan(field, field_flow):
-                        return False
+                field = args.get(name)
+                if field:
+                    field = field[-1]
+                if not match_field_dl_vlan(field, field_flow):
+                    return False
                 continue
             if name not in args:
                 return False

--- a/main.py
+++ b/main.py
@@ -198,13 +198,13 @@ class Main(KytosNApp):
             return False
         for name in flow['flow']['match']:
             field_flow = flow['flow']['match'][name]
-            if name not in args:
-                return False
             if name == 'dl_vlan':
-                field = args[name][-1]
+                field = args[name][-1] if name in args else 0
                 if not match_field_dl_vlan(field, field_flow):
                     return False
                 continue
+            if name not in args:
+                return False
             field = args[name]
             if name not in ('ipv4_src', 'ipv4_dst', 'ipv6_src', 'ipv6_dst'):
                 if field_flow != field:

--- a/main.py
+++ b/main.py
@@ -194,14 +194,19 @@ class Main(KytosNApp):
     def do_match(cls, flow, args):
         """Match a packet against this flow (OF1.3)."""
         # pylint: disable=consider-using-dict-items
+        # pylint: disable=too-many-return-statements
         if ('match' not in flow['flow']) or (len(flow['flow']['match']) == 0):
             return False
         for name in flow['flow']['match']:
             field_flow = flow['flow']['match'][name]
             if name == 'dl_vlan':
-                field = args[name][-1] if name in args else 0
-                if not match_field_dl_vlan(field, field_flow):
-                    return False
+                if name not in args:
+                    if field_flow != 0:
+                        return False
+                else:
+                    field = args[name][-1]
+                    if not match_field_dl_vlan(field, field_flow):
+                        return False
                 continue
             if name not in args:
                 return False

--- a/openapi.yml
+++ b/openapi.yml
@@ -37,14 +37,8 @@ paths:
                       type: object
                       properties:
                         dl_vlan:
-                          description: VLAN ID
-                          oneOf:
-                            - type: integer
-                              format: int32
-                            - type: string
-                              enum:
-                                - any
-                                - untagged                          
+                          type: integer
+                          description: VLAN ID                         
                           example: 100
                         dl_type:
                           type: string
@@ -123,15 +117,9 @@ paths:
                           description: Type of the step. May be "starting", "intermediary", "loop" or "incomplete".
                           example: "intermediary"
                         vlan:
+                          type: integer
                           description: VLAN ID
                           example: 100
-                          oneOf:
-                            - type: integer
-                              format: int32
-                            - type: string
-                              enum:
-                                - any
-                                - untagged  
         400:
           description: "Parameter 'dpid' and/or 'in_port' is missing"
           content:
@@ -227,14 +215,8 @@ paths:
                         type: object
                         properties:
                           dl_vlan:
-                            description: VLAN ID
-                            oneOf:
-                              - type: integer
-                                format: int32
-                              - type: string
-                                enum:
-                                  - any
-                                  - untagged                          
+                            type: integer
+                            description: VLAN ID                        
                             example: 100
                           dl_type:
                             type: string
@@ -312,12 +294,7 @@ paths:
                             description: Type of the step. May be "starting", "intermediary", "loop" or "incomplete".
                             example: "intermediary"
                           vlan:
+                            type: integer
                             description: VLAN ID
                             example: 100
-                            oneOf:
-                              - type: integer
-                                format: int32
-                              - type: string
-                                enum:
-                                  - any
-                                  - untagged  
+

--- a/openapi.yml
+++ b/openapi.yml
@@ -38,7 +38,7 @@ paths:
                       properties:
                         dl_vlan:
                           type: integer
-                          description: VLAN ID
+                          description: VLAN ID. This is an integer in range [1, 4095].
                           example: 100
                         dl_type:
                           type: string
@@ -216,7 +216,7 @@ paths:
                         properties:
                           dl_vlan:
                             type: integer
-                            description: VLAN ID
+                            description: VLAN ID. This is an integer in range [1, 4095].
                             example: 100
                           dl_type:
                             type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -37,8 +37,14 @@ paths:
                       type: object
                       properties:
                         dl_vlan:
-                          type: integer
                           description: VLAN ID
+                          oneOf:
+                            - type: integer
+                              format: int32
+                            - type: string
+                              enum:
+                                - any
+                                - untagged                          
                           example: 100
                         dl_type:
                           type: string
@@ -117,9 +123,15 @@ paths:
                           description: Type of the step. May be "starting", "intermediary", "loop" or "incomplete".
                           example: "intermediary"
                         vlan:
-                          type: integer
                           description: VLAN ID
                           example: 100
+                          oneOf:
+                            - type: integer
+                              format: int32
+                            - type: string
+                              enum:
+                                - any
+                                - untagged  
         400:
           description: "Parameter 'dpid' and/or 'in_port' is missing"
           content:
@@ -215,8 +227,14 @@ paths:
                         type: object
                         properties:
                           dl_vlan:
-                            type: integer
                             description: VLAN ID
+                            oneOf:
+                              - type: integer
+                                format: int32
+                              - type: string
+                                enum:
+                                  - any
+                                  - untagged                          
                             example: 100
                           dl_type:
                             type: string
@@ -294,6 +312,12 @@ paths:
                             description: Type of the step. May be "starting", "intermediary", "loop" or "incomplete".
                             example: "intermediary"
                           vlan:
-                            type: integer
                             description: VLAN ID
                             example: 100
+                            oneOf:
+                              - type: integer
+                                format: int32
+                              - type: string
+                                enum:
+                                  - any
+                                  - untagged  

--- a/openapi.yml
+++ b/openapi.yml
@@ -38,7 +38,7 @@ paths:
                       properties:
                         dl_vlan:
                           type: integer
-                          description: VLAN ID                         
+                          description: VLAN ID
                           example: 100
                         dl_type:
                           type: string
@@ -216,7 +216,7 @@ paths:
                         properties:
                           dl_vlan:
                             type: integer
-                            description: VLAN ID                        
+                            description: VLAN ID
                             example: 100
                           dl_type:
                             type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -38,7 +38,7 @@ paths:
                       properties:
                         dl_vlan:
                           type: integer
-                          description: VLAN ID. This is an integer in range [1, 4095].
+                          description: VLAN ID. This is an integer in range [1, 4095] as in a network packet.
                           example: 100
                         dl_type:
                           type: string
@@ -216,7 +216,7 @@ paths:
                         properties:
                           dl_vlan:
                             type: integer
-                            description: VLAN ID. This is an integer in range [1, 4095].
+                            description: VLAN ID. This is an integer in range [1, 4095] as in a network packet.
                             example: 100
                           dl_type:
                             type: string

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -726,7 +726,7 @@ class TestMain(TestCase):
                     "dpid": "00:00:00:00:00:00:00:01",
                     "in_port": 1
                     },
-                "eth": {"dl_vlan": 0},
+                "eth": {"dl_vlan": 10},
             }
         }, {
             "trace": {
@@ -735,25 +735,11 @@ class TestMain(TestCase):
                     "in_port": 1
                     }
             }
-        }, {
-            "trace": {
-                "switch": {
-                    "dpid": "00:00:00:00:00:00:00:01",
-                    "in_port": 1
-                    },
-                "eth": {"dl_vlan": 10},
-            }
         }
         ]
 
-        stored_flow = {
-            "id": 1,
+        stored_flow1 = {
             "flow": {
-                "table_id": 0,
-                "cookie": 84114964,
-                "hard_timeout": 0,
-                "idle_timeout": 0,
-                "priority": 100,
                 "match": {"dl_vlan": 0, "in_port": 1},
                 "actions": [
                     {"action_type": "pop_vlan"},
@@ -761,93 +747,9 @@ class TestMain(TestCase):
                 ],
             }
         }
-        stored_flow1 = {
-            "id": 1,
-            "flow": {
-                "table_id": 0,
-                "cookie": 84114964,
-                "hard_timeout": 0,
-                "idle_timeout": 0,
-                "priority": 10,
-                "match": {"in_port": 1},
-                "actions": [
-                    {"action_type": "pop_vlan"},
-                    {"action_type": "output", "port": 3},
-                ],
-            }
-        }
-        mock_stored_flows.return_value = {
-            "00:00:00:00:00:00:00:01": [stored_flow, stored_flow1]
-        }
-
-        response = api.put(
-            url, data=json.dumps(payload), content_type="application/json"
-        )
-        current_data = json.loads(response.data)
-        result = current_data["result"]
-        assert result[0][0]["type"] == "last"
-        assert result[0][0]["out"] == {"port": 2}
-        assert result[1][0]["type"] == "last"
-        assert result[1][0]["out"] == {"port": 2}
-        assert result[2][0]["type"] == "last"
-        assert result[2][0]["out"] == {"port": 2}
-
-    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
-    def test_get_traces_any(self, mock_stored_flows):
-        """Test traces rest call."""
-        api = get_test_client(get_controller_mock(), self.napp)
-        url = f"{self.server_name_url}/traces/"
-
-        payload = [{
-            "trace": {
-                "switch": {
-                    "dpid": "00:00:00:00:00:00:00:01",
-                    "in_port": 1
-                    },
-                "eth": {"dl_vlan": 10}
-            }
-        }, {
-            "trace": {
-                "switch": {
-                    "dpid": "00:00:00:00:00:00:00:01",
-                    "in_port": 1
-                    },
-                "eth": {"dl_vlan": 0}
-            }
-        }, {
-            "trace": {
-                "switch": {
-                    "dpid": "00:00:00:00:00:00:00:01",
-                    "in_port": 1
-                    }
-            }
-        }
-        ]
-
-        stored_flow1 = {
-            "id": 1,
-            "flow": {
-                "table_id": 0,
-                "cookie": 84114964,
-                "hard_timeout": 0,
-                "idle_timeout": 0,
-                "priority": 1000,
-                "match": {"dl_vlan": "4096/4096", "in_port": 1},
-                "actions": [
-                    {"action_type": "pop_vlan"},
-                    {"action_type": "output", "port": 2},
-                ],
-            }
-        }
         stored_flow2 = {
-            "id": 1,
             "flow": {
-                "table_id": 0,
-                "cookie": 84114964,
-                "hard_timeout": 0,
-                "idle_timeout": 0,
-                "priority": 100,
-                "match": {"dl_vlan": 10, "in_port": 1},
+                "match": {"in_port": 1},
                 "actions": [
                     {"action_type": "pop_vlan"},
                     {"action_type": "output", "port": 3},
@@ -855,14 +757,8 @@ class TestMain(TestCase):
             }
         }
         stored_flow3 = {
-            "id": 1,
             "flow": {
-                "table_id": 0,
-                "cookie": 84114964,
-                "hard_timeout": 0,
-                "idle_timeout": 0,
-                "priority": 10,
-                "match": {"in_port": 1},
+                "match": {"dl_vlan": 10, "in_port": 1},
                 "actions": [
                     {"action_type": "pop_vlan"},
                     {"action_type": "output", "port": 1},
@@ -883,38 +779,15 @@ class TestMain(TestCase):
         current_data = json.loads(response.data)
         result = current_data["result"]
         assert result[0][0]["type"] == "last"
-        assert result[0][0]["out"] == {"port": 2}
-        assert result[1][0]["type"] == "last"
-        assert result[1][0]["out"] == {"port": 2}
-        assert result[1][0]["type"] == "last"
-        assert result[1][0]["out"] == {"port": 2}
-
-        stored_flow2['flow']['priority'] = 2000
-        mock_stored_flows.return_value = {
-            "00:00:00:00:00:00:00:01": [
-                stored_flow2,
-                stored_flow1,
-                stored_flow3
-            ]
-        }
-        response = api.put(
-            url, data=json.dumps(payload), content_type="application/json"
-        )
-        current_data = json.loads(response.data)
-        result = current_data["result"]
-        assert result[0][0]["type"] == "last"
         assert result[0][0]["out"] == {"port": 3}
         assert result[1][0]["type"] == "last"
-        assert result[1][0]["out"] == {"port": 3}
-        assert result[1][0]["type"] == "last"
-        assert result[1][0]["out"] == {"port": 3}
+        assert result[1][0]["out"] == {"port": 2}
 
-        stored_flow3['flow']['priority'] = 3000
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [
                 stored_flow3,
-                stored_flow1,
-                stored_flow2
+                stored_flow2,
+                stored_flow1
             ]
         }
 
@@ -925,7 +798,103 @@ class TestMain(TestCase):
         result = current_data["result"]
         assert result[0][0]["type"] == "loop"
         assert result[0][0]["out"] == {"port": 1}
-        assert result[1][0]["type"] == "loop"
-        assert result[1][0]["out"] == {"port": 1}
-        assert result[1][0]["type"] == "loop"
-        assert result[1][0]["out"] == {"port": 1}
+        assert result[1][0]["type"] == "last"
+        assert result[1][0]["out"] == {"port": 3}
+
+    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
+    def test_get_traces_any(self, mock_stored_flows):
+        """Test traces rest call."""
+        api = get_test_client(get_controller_mock(), self.napp)
+        url = f"{self.server_name_url}/traces/"
+
+        payload = [{
+            "trace": {
+                "switch": {
+                    "dpid": "00:00:00:00:00:00:00:01",
+                    "in_port": 1
+                    },
+                "eth": {"dl_vlan": 10}
+            }
+        }, {
+            "trace": {
+                "switch": {
+                    "dpid": "00:00:00:00:00:00:00:01",
+                    "in_port": 1
+                    }
+            }
+        }
+        ]
+
+        stored_flow1 = {
+            "flow": {
+                "match": {"dl_vlan": "4096/4096", "in_port": 1},
+                "actions": [
+                    {"action_type": "pop_vlan"},
+                    {"action_type": "output", "port": 2},
+                ],
+            }
+        }
+        stored_flow2 = {
+            "flow": {
+                "match": {"dl_vlan": 10, "in_port": 1},
+                "actions": [
+                    {"action_type": "pop_vlan"},
+                    {"action_type": "output", "port": 1},
+                ],
+            }
+        }
+        stored_flow3 = {
+            "flow": {
+                "match": {"dl_vlan": "10/10", "in_port": 1},
+                "actions": [
+                    {"action_type": "pop_vlan"},
+                    {"action_type": "output", "port": 3},
+                ],
+            }
+        }
+        stored_flow4 = {
+            "flow": {
+                "match": {"dl_vlan": "20/10", "in_port": 1},
+                "actions": [
+                    {"action_type": "pop_vlan"},
+                    {"action_type": "output", "port": 1},
+                ],
+            }
+        }
+        mock_stored_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [
+                stored_flow1,
+                stored_flow2,
+                stored_flow3,
+                stored_flow4
+            ]
+        }
+
+        response = api.put(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        current_data = json.loads(response.data)
+        result = current_data["result"]
+        assert result[0][0]["type"] == "last"
+        assert result[0][0]["out"] == {"port": 2}
+        assert result[1][0]["type"] == "incomplete"
+        assert result[1][0]["out"] is None
+
+        mock_stored_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [
+                stored_flow4,
+                stored_flow3,
+                stored_flow2,
+                stored_flow1
+            ]
+        }
+
+        response = api.put(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        current_data = json.loads(response.data)
+        result = current_data["result"]
+        assert result[0][0]["type"] == "last"
+        assert result[0][0]["out"] == {"port": 3}
+        assert result[1][0]["type"] == "incomplete"
+        assert result[1][0]["out"] is None

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -866,15 +866,34 @@ class TestMain(TestCase):
                 "hard_timeout": 0,
                 "idle_timeout": 0,
                 "priority": 100,
-                "match": {"dl_vlan": 10, "in_port": 1},
+                "match": {"dl_vlan": "4096/4096", "in_port": 1},
                 "actions": [
                     {"action_type": "pop_vlan"},
                     {"action_type": "output", "port": 3},
                 ],
             }
         }
+        stored_flow3 = {
+            "id": 1,
+            "flow": {
+                "table_id": 0,
+                "cookie": 84114964,
+                "hard_timeout": 0,
+                "idle_timeout": 0,
+                "priority": 10,
+                "match": {"dl_vlan": 10, "in_port": 1},
+                "actions": [
+                    {"action_type": "pop_vlan"},
+                    {"action_type": "output", "port": 1},
+                ],
+            }
+        }
         mock_stored_flows.return_value = {
-            "00:00:00:00:00:00:00:01": [stored_flow1, stored_flow2]
+            "00:00:00:00:00:00:00:01": [
+                stored_flow1,
+                stored_flow2,
+                stored_flow3
+            ]
         }
 
         response = api.put(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -427,6 +427,33 @@ class TestUtils(TestCase):
         result = utils.find_endpoint(mock_switch, port)
         self.assertIsNone(result)
 
+    def test_convert_vlan(self):
+        """Test convert_vlan function"""
+        value = 100
+        result = utils.convert_vlan(value)
+        assert result[0] == 100
+
+        value = "4096/4096"
+        result = utils.convert_vlan(value)
+        assert result[0] == 4096
+        assert result[1] == 4096
+
+    def test_match_field_dl_vlan(self):
+        """Test match_field_dl_vlan"""
+
+        result = utils.match_field_dl_vlan(None, 0)
+        self.assertTrue(result)
+        result = utils.match_field_dl_vlan(None, 10)
+        self.assertFalse(result)
+        result = utils.match_field_dl_vlan(None, "4096/4096")
+        self.assertFalse(result)
+        result = utils.match_field_dl_vlan(10, 0)
+        self.assertFalse(result)
+        result = utils.match_field_dl_vlan(10, 10)
+        self.assertTrue(result)
+        result = utils.match_field_dl_vlan(10, "4096/4096")
+        self.assertTrue(result)
+
 
 # pylint: disable=too-many-public-methods, too-many-lines
 class TestUtilsWithController(TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -453,6 +453,12 @@ class TestUtils(TestCase):
         self.assertTrue(result)
         result = utils.match_field_dl_vlan(10, "4096/4096")
         self.assertTrue(result)
+        result = utils.match_field_dl_vlan(10, 11)
+        self.assertFalse(result)
+        result = utils.match_field_dl_vlan(3, "5/1")
+        self.assertTrue(result)
+        result = utils.match_field_dl_vlan(2, "5/1")
+        self.assertFalse(result)
 
 
 # pylint: disable=too-many-public-methods, too-many-lines

--- a/utils.py
+++ b/utils.py
@@ -169,13 +169,9 @@ def convert_vlan(value):
     return value, mask
 
 
-def match_field_dl_vlan(vlan_value, field_flow):
-    """Verify match in dl_vlan"""
-    value, mask = convert_vlan(vlan_value)
-    vlan = value & (mask & 4095)
+def match_field_dl_vlan(value, field_flow):
+    """Verify match in dl_vlan.
+    vlan only takes integer values in range [1,4095].
+    0 is not allowed for vlan, just the untagged case."""
     value_flow, mask_flow = convert_vlan(field_flow)
-    vlan_flow = value_flow & (mask_flow & 4095)
-    # untagged cases
-    if vlan == 0 or vlan_flow == 0:
-        return True
-    return vlan == vlan_flow
+    return value & (mask_flow & 4095) == value_flow & (mask_flow & 4095)

--- a/utils.py
+++ b/utils.py
@@ -170,8 +170,10 @@ def convert_vlan(value):
 
 
 def match_field_dl_vlan(value, field_flow):
-    """Verify match in dl_vlan.
-    vlan only takes integer values in range [1,4095].
-    0 is not allowed for vlan, just the untagged case."""
+    """ Verify match in dl_vlan.
+    value only takes an int in range [1,4095].
+    0 is not allowed for value. """
+    if not value:
+        return field_flow == 0
     value_flow, mask_flow = convert_vlan(field_flow)
     return value & (mask_flow & 4095) == value_flow & (mask_flow & 4095)

--- a/utils.py
+++ b/utils.py
@@ -161,10 +161,12 @@ def _compare_endpoints(endpoint1, endpoint2):
     return True
 
 
-def map_dl_vlan(vlan_value):
-    """Return 4096/4096 and 0 respectively in case of any and untagged"""
+def match_field_dl_vlan(vlan_value, field_flow):
+    """Verify match in dl_vlan"""
     special = {"any": "4096/4096", "untagged": 0}
-
-    if isinstance(vlan_value, str):
-        return special.get(vlan_value, vlan_value)
-    return vlan_value
+    if vlan_value in special:
+        vlan_value = special.get(vlan_value, vlan_value)
+    if isinstance(vlan_value, int):
+        return vlan_value == field_flow
+    value, mask = map(int, vlan_value.split('/'))
+    return value & (mask & 4095) == field_flow & (mask & 4095)

--- a/utils.py
+++ b/utils.py
@@ -159,3 +159,12 @@ def _compare_endpoints(endpoint1, endpoint2):
     elif 'out_vlan' in endpoint1 or 'in_vlan' in endpoint2:
         return False
     return True
+
+
+def map_dl_vlan(vlan_value):
+    """Return 4096/4096 and 0 respectively in case of any and untagged"""
+    special = {"any": "4096/4096", "untagged": 0}
+
+    if isinstance(vlan_value, str):
+        return special.get(vlan_value, vlan_value)
+    return vlan_value

--- a/utils.py
+++ b/utils.py
@@ -163,20 +163,19 @@ def _compare_endpoints(endpoint1, endpoint2):
 
 def convert_vlan(value):
     """Auxiliar function to calculate dl_vlan"""
-    special = {"any": "4096/4096", "untagged": 0}
-    value = special.get(value, value)
     if isinstance(value, int):
-        return value, -1
+        return value, 4095
     value, mask = map(int, value.split('/'))
-    return value & (mask & 4095), mask
+    return value, mask
 
 
 def match_field_dl_vlan(vlan_value, field_flow):
     """Verify match in dl_vlan"""
     value, mask = convert_vlan(vlan_value)
+    vlan = value & (mask & 4095)
     value_flow, mask_flow = convert_vlan(field_flow)
-    if mask == -1 and mask_flow != -1:
-        return value & (mask_flow & 4095) == value_flow
-    if mask != -1 and mask_flow == -1:
-        return value == value_flow & (mask & 4095)
-    return value == value_flow
+    vlan_flow = value_flow & (mask_flow & 4095)
+    # untagged cases
+    if vlan == 0 or vlan_flow == 0:
+        return True
+    return vlan == vlan_flow

--- a/utils.py
+++ b/utils.py
@@ -164,8 +164,7 @@ def _compare_endpoints(endpoint1, endpoint2):
 def match_field_dl_vlan(vlan_value, field_flow):
     """Verify match in dl_vlan"""
     special = {"any": "4096/4096", "untagged": 0}
-    if vlan_value in special:
-        vlan_value = special.get(vlan_value, vlan_value)
+    vlan_value = special.get(vlan_value, vlan_value)
     if isinstance(vlan_value, int):
         return vlan_value == field_flow
     value, mask = map(int, vlan_value.split('/'))


### PR DESCRIPTION
Closes #79 

### Summary

Map the special `untagged` and `any` values of `vlan` to match the stored flows.

### Local Tests

Request:
```
[
  {
    "trace": {
      "switch": {
        "dpid": "00:00:00:00:00:00:00:02",
        "in_port": 1
      },
      "eth": {
        "dl_vlan": "untagged"
      }
    }
  },{
    "trace": {
      "switch": {
        "dpid": "00:00:00:00:00:00:00:01",
        "in_port": 1
      },
      "eth": {
        "dl_vlan": "any"
      }
    }
  }
]
```

Answer:
```
{
    "result": [
        [
            {
                "dpid": "00:00:00:00:00:00:00:02",
                "port": 1,
                "time": "2023-03-16 12:18:33.022395",
                "type": "starting",
                "vlan": "untagged"
            },
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "out": null,
                "port": 2,
                "time": "2023-03-16 12:18:33.022927",
                "type": "incomplete",
                "vlan": 100
            }
        ],
        [
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "out": null,
                "port": 1,
                "time": "2023-03-16 12:18:33.023045",
                "type": "incomplete",
                "vlan": "any"
            }
        ]
    ]
}
```

### End-to-End Tests

+ python3 -m pytest tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_070_run_sdntrace_str_vlan
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 1 item

tests/test_e2e_40_sdntrace.py .                                          [100%]

=============================== warnings summary ===============================
test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 98 warnings in 117.95s (0:01:57) ==================