### PR TITLE
feature: validate payload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 Added
 =====
 - Support "untagged" and "any" on EVCs.
+- `PUT /trace and /traces` endpoints validate payload with ``@validate_openapi`` from kytos.core.
 
 Changed
 =======

--- a/openapi.yml
+++ b/openapi.yml
@@ -40,8 +40,10 @@ paths:
                           type: integer
                           description: VLAN ID. This is an integer in range [1, 4095] as in a network packet.
                           example: 100
+                          minimum: 1
+                          maximum: 4095
                         dl_type:
-                          type: string
+                          type: integer
                           description: Ethernet type
                           example: '0x8100'
                         dl_src:
@@ -218,8 +220,10 @@ paths:
                             type: integer
                             description: VLAN ID. This is an integer in range [1, 4095] as in a network packet.
                             example: 100
+                            minimum: 1
+                            maximum: 4095
                           dl_type:
-                            type: string
+                            type: integer
                             description: Ethernet type
                           dl_src:
                             type: string

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -416,48 +416,6 @@ class TestMain(TestCase):
         assert result[0]["out"] == {"port": 2, "vlan": 200}
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
-    def test_trace_missing_parameter(self, mock_stored_flows):
-        """Test trace rest call with a missing parameter."""
-        api = get_test_client(get_controller_mock(), self.napp)
-        url = f"{self.server_name_url}/trace/"
-
-        payload = {
-            "trace": {
-                "switch": {
-                    "in_port": 1
-                    },
-                "eth": {"dl_vlan": 100},
-            }
-        }
-        stored_flows = {
-                "flow": {
-                    "table_id": 0,
-                    "cookie": 84114964,
-                    "hard_timeout": 0,
-                    "idle_timeout": 0,
-                    "priority": 10,
-                    "match": {"dl_vlan": 100, "in_port": 1},
-                    "actions": [
-                        {"action_type": "push_vlan"},
-                        {"action_type": "set_vlan", "vlan_id": 200},
-                        {"action_type": "output", "port": 2}
-                    ],
-                },
-                "flow_id": 1,
-                "state": "installed",
-                "switch": "00:00:00:00:00:00:00:01",
-        }
-        mock_stored_flows.return_value = {
-            "00:00:00:00:00:00:00:01": [stored_flows]
-        }
-
-        response = api.put(
-            url, data=json.dumps(payload), content_type="application/json"
-        )
-        current_data = json.loads(response.data)
-        assert current_data["result"] == []
-
-    @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     def test_get_traces(self, mock_stored_flows):
         """Test traces rest call."""
         api = get_test_client(get_controller_mock(), self.napp)
@@ -540,13 +498,6 @@ class TestMain(TestCase):
                         "trace": {
                             "switch": {
                                 "dpid": "00:00:00:00:00:00:00:02",
-                            }
-                        }
-                    },
-                    {
-                        "trace": {
-                            "switch": {
-                                "dpid": "00:00:00:00:00:00:00:02",
                                 "in_port": 2
                             },
                             "eth": {
@@ -579,7 +530,7 @@ class TestMain(TestCase):
         )
         current_data = json.loads(response.data)
         result = current_data["result"]
-        assert len(result) == 4
+        assert len(result) == 3
 
         assert result[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert result[0][0]["port"] == 1
@@ -593,13 +544,11 @@ class TestMain(TestCase):
         assert result[1][0]["vlan"] == 100
         assert result[1][0]["out"] is None
 
-        assert result[2] == []
-
-        assert result[3][0]["dpid"] == "00:00:00:00:00:00:00:02"
-        assert result[3][0]["port"] == 2
-        assert result[3][0]["type"] == "incomplete"
-        assert result[3][0]["vlan"] == 100
-        assert result[3][0]["out"] is None
+        assert result[2][0]["dpid"] == "00:00:00:00:00:00:00:02"
+        assert result[2][0]["port"] == 2
+        assert result[2][0]["type"] == "incomplete"
+        assert result[2][0]["vlan"] == 100
+        assert result[2][0]["out"] is None
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     def test_traces_with_loop(self, mock_stored_flows):


### PR DESCRIPTION
Closes #63 

### Summary

This PR is to add validation in `PUT /trace and /traces` with `@validate_openapi` from `kytos.core.helpers`. 

### Local Tests

Below is a list of requests, the first one is correct and the rest have errors that the validation should detect.

1. Correct request:
```
[
    {
        "trace": {
            "switch": {
                "dpid": "00:00:00:00:00:00:00:01",
                "in_port": 3
            },
            "eth": {
      "         dl_vlan": 10
            }
        }
  }
]
```

Answer:
```
{
    "result": [
        [
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "out": null,
                "port": 3,
                "time": "2023-04-03 16:05:24.858854",
                "type": "incomplete"
            }
        ]
    ]
}
```

Invalid cases:

2. Mandatory parameter missing:
```
[
    {
        "trace": {
            "switch": {
                "dpid": "00:00:00:00:00:00:00:01"
            },
            "eth": {
      "         dl_vlan": 10
            }
        }
  }
]
```
Answer:

```
{
    "code": 400,
    "description": "The request body contains invalid API data. 'in_port' is a required property for field 0/trace/switch.",
    "name": "Bad Request"
}
```

3. Wrong data type:
```
[
    {
        "trace": {
            "switch": {
                "dpid": 1,
                "in_port": 3
            },
            "eth": {
      "         dl_vlan": 10
            }
        }
  }
]
```

Answer:
```
{
    "code": 400,
    "description": "The request body contains invalid API data. 1 is not of type 'string' for field 0/trace/switch/dpid.",
    "name": "Bad Request"
}
```

4. Wrong `dl_vlan`:

```
[
    {
        "trace": {
            "switch": {
                "dpid": "00:00:00:00:00:00:00:01",
                "in_port": 3
            },
            "eth": {
                "dl_vlan": "10"
            }
        }
  }
]
```

Answer:

```
{
    "code": 400,
    "description": "The request body contains invalid API data. '10' is not of type 'integer' for field 0/trace/eth/dl_vlan.",
    "name": "Bad Request"
}
```
Same message for the cases: `any`, `untagged` and `4096/4096`

### End-to-End Tests

+ python3 -m pytest tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_080_validate_attribute_on_payload
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 1 item

tests/test_e2e_40_sdntrace.py .                                          [100%]

=============================== warnings summary ===============================
test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 98 warnings in 123.34s (0:02:03) ==================
