### PR TITLE
Fix issue on interface not found

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 =====
 - Check the ``actions`` field in flows when running Sdntrace to avoid KeyError.
 - In ``PUT /trace`` and ``PUT /traces``, field ``switch``` is defined as required, as well as its parameters ``dpid``` and ``in_port``.
+- Check that an interface has been found with ``find_endpoint`` given ``switch`` and ``port`` at each ``trace_step``.
 
 [2022.3.1] - 2023-02-27
 ***********************

--- a/main.py
+++ b/main.py
@@ -180,7 +180,7 @@ class Main(KytosNApp):
 
         endpoint = find_endpoint(switch, port)
         if endpoint is None:
-            log.warning("Interface not found")
+            log.warning(f"Port {port} not found on switch {switch}")
             return None
         endpoint = endpoint['endpoint']
         if endpoint is None:

--- a/main.py
+++ b/main.py
@@ -180,7 +180,7 @@ class Main(KytosNApp):
 
         endpoint = find_endpoint(switch, port)
         if endpoint is None:
-            log.warning(f'Interface not found')
+            log.warning("Interface not found")
             return None
         endpoint = endpoint['endpoint']
         if endpoint is None:

--- a/main.py
+++ b/main.py
@@ -180,6 +180,10 @@ class Main(KytosNApp):
 
         endpoint = find_endpoint(switch, port)
         if endpoint is None:
+            log.warning(f'Interface not found')
+            return None
+        endpoint = endpoint['endpoint']
+        if endpoint is None:
             return {'out_port': port,
                     'entries': entries}
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -394,9 +394,9 @@ class TestUtils(TestCase):
 
         mock_switch = MagicMock()
         mock_switch.get_interface_by_port_no.return_value = mock_interface
-
+        expected = {'endpoint': mock_interface.link.endpoint_a}
         result = utils.find_endpoint(mock_switch, port)
-        self.assertEqual(result, mock_interface.link.endpoint_a)
+        self.assertEqual(result, expected)
 
     def test_find_endpoint_a(self):
         """Test find endpoint with interface equals link endpoint A."""
@@ -410,9 +410,9 @@ class TestUtils(TestCase):
 
         mock_switch = MagicMock()
         mock_switch.get_interface_by_port_no.return_value = mock_interface
-
+        expected = {'endpoint': mock_interface.link.endpoint_b}
         result = utils.find_endpoint(mock_switch, port)
-        self.assertEqual(result, mock_interface.link.endpoint_b)
+        self.assertEqual(result, expected)
 
     def test_find_endpoint_link_none(self):
         """Test find endpoint without link."""
@@ -425,7 +425,8 @@ class TestUtils(TestCase):
         mock_switch.get_interface_by_port_no.return_value = mock_interface
 
         result = utils.find_endpoint(mock_switch, port)
-        self.assertIsNone(result)
+        assert 'endpoint' in result
+        self.assertIsNone(result['endpoint'])
 
     def test_convert_vlan(self):
         """Test convert_vlan function"""

--- a/utils.py
+++ b/utils.py
@@ -56,11 +56,13 @@ def find_endpoint(switch, port):
     returns the interface it is connected to, otherwise returns None """
 
     interface = switch.get_interface_by_port_no(port)
-    if interface.link:
+    if not interface:
+        return None
+    if interface and interface.link:
         if interface == interface.link.endpoint_a:
-            return interface.link.endpoint_b
-        return interface.link.endpoint_a
-    return None
+            return {'endpoint': interface.link.endpoint_b}
+        return {'endpoint': interface.link.endpoint_a}
+    return {'endpoint': None}
 
 
 def _prepare_json(trace_result):


### PR DESCRIPTION
Closes #88 

### Summary

When interface not found in a trace, it will be considered an `incomplete` trace. i.e. It is the same case as when t`race_step` early returns None if not flow or not port.

### Local Tests

[No warning seen.](https://github.com/kytos-ng/sdntrace_cp/blob/896fe9b9d7afff9aafcdf0d48ce5f395b193fd19/main.py#L183)

### End-to-End Tests

progress