### PR TITLE
feature: Remove parameters `last_id` and `traces` &  `/{trace_id}` from openapi.yml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Changed
 =======
 - Update ``tracepath`` to support two new trace types: `loop` and `incomplete`. The `trace` type is now `intermediary`. The `incomplete`` type replaces the empty list that was returned as a response in some cases.
 - Add new case of `loop` when the outgoing interface is the same as the input interface.
+- Remove ``last_id`` and ``traces`` parameters
+- Remove ``GET /api/amlight/sdntrace_cp/trace/{trace_id}`` in ``openapi.yml``
 
 Fixed
 =====

--- a/main.py
+++ b/main.py
@@ -36,8 +36,6 @@ class Main(KytosNApp):
         """
         log.info("Starting Kytos SDNTrace CP App!")
 
-        self.traces = {}
-        self.last_id = 30000
         self.automate = Automate(self)
         self.automate.schedule_traces()
         self.automate.schedule_important_traces()
@@ -86,8 +84,6 @@ class Main(KytosNApp):
     def tracepath(self, entries, stored_flows):
         """Trace a path for a packet represented by entries."""
         # pylint: disable=too-many-branches
-        self.last_id += 1
-        trace_id = self.last_id
         trace_result = []
         trace_type = 'starting'
         do_trace = True
@@ -135,9 +131,6 @@ class Main(KytosNApp):
                 if self.check_loop_trace_step(trace_step, trace_result):
                     do_trace = False
             trace_result.append(trace_step)
-        self.traces.update({
-            trace_id: trace_result
-        })
         return trace_result
 
     @staticmethod

--- a/openapi.yml
+++ b/openapi.yml
@@ -129,59 +129,6 @@ paths:
               schema:
                 type: string
                 example: Bad request
-  /api/amlight/sdntrace_cp/trace/{trace_id}:
-    get:
-      summary: Get the result of a trace
-      parameters:
-        - name: trace_id
-          schema:
-            type: integer
-          required: true
-          description: Trace ID
-          in: path
-      responses:
-        200:
-          description: Ok.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  request:
-                    type: object
-                  request_id:
-                    type: integer
-                    description: ID of the trace
-                    example: 30001
-                  result:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        dpid:
-                          type: string
-                          description: Datapath ID of the switch
-                          example: 00:00:00:00:00:00:00:01
-                        port:
-                          type: integer
-                          description: Incoming port of the packet in this switch
-                          example: 1
-                        time:
-                          type: string
-                          description: Start time in the first switch, elapsed time otherwise
-                          example: "2018-03-22 14:50:56.888483"
-                        type:
-                          type: string
-                          description: Type of this step. May be starting, intermediary, last or loop.
-                          example: intermediary
-                  start_time:
-                    type: string
-                    description: Start time of the trace
-                    example: "2018-03-22 14:50:56.888483"
-                  total_time:
-                    type: string
-                    description: "Elapsed time on this trace"
-                    example: "0:00:00.256709"
   /api/amlight/sdntrace_cp/traces:
     put:
       summary: Trace paths given switches


### PR DESCRIPTION
Closes #16 
Closes #17 

### Summary

Remove `last_id` and `traces`  since  they aren't being used as #16 mentioned.
Remove `GET /api/amlight/sdntrace_cp/trace/{trace_id}` since it does not have an implementation. 

### Local Tests

`/traces` continues working well:
Example:
```
[
    {
        "trace": {
            "switch": {
                "dpid": "00:00:00:00:00:00:00:01",
                "in_port": 1
            }
        }
  }
]
```

```
{
    "result": [
        [
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "port": 1,
                "time": "2023-04-10 11:41:30.778149",
                "type": "starting"
            },
            {
                "dpid": "00:00:00:00:00:00:00:02",
                "out": null,
                "port": 2,
                "time": "2023-04-10 11:41:30.778206",
                "type": "incomplete"
            }
        ]
    ]
}
```

### End-to-End Tests

N/A
