### PR TITLE
Update `type` as enum and add `last` type in openapi.yml

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -116,7 +116,8 @@ paths:
                           example: "2022-01-25 13:44:52.387021"
                         type:
                           type: string
-                          description: Type of the step. May be "starting", "intermediary", "loop" or "incomplete".
+                          enum: ["starting", "intermediary", "last", "loop", "incomplete"]
+                          description: Type of the step. May be "starting", "intermediary", "last", and "loop" or "incomplete" for failure.
                           example: "intermediary"
                         vlan:
                           type: integer
@@ -242,7 +243,8 @@ paths:
                             example: "2022-01-25 13:44:52.387021"
                           type:
                             type: string
-                            description: Type of the step. May be "starting", "intermediary", "loop" or "incomplete".
+                            enum: ["starting", "intermediary", "last", "loop", "incomplete"]
+                            description: Type of the step. May be "starting", "intermediary", "last", and "loop" or "incomplete" for failure.
                             example: "intermediary"
                           vlan:
                             type: integer


### PR DESCRIPTION
This is related to PR #91 

### Summary

Add `last` type & update type to be an enum of string: ["starting", "intermediary", "last", "loop", "incomplete"]

### Local Tests

I made sure it loads fine:

```
{
    "result": [
        [
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "port": 1,
                "time": "2023-04-10 17:01:08.172320",
                "type": "starting"
            },
            {
                "dpid": "00:00:00:00:00:00:00:02",
                "out": null,
                "port": 2,
                "time": "2023-04-10 17:01:08.172398",
                "type": "incomplete"
            }
        ]
    ]
}
```

### End-to-End Tests

N/A