### PR TITLE
feature: Add v1 routes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,6 @@ Added
 =====
 - Support "untagged" and "any" on EVCs.
 - `PUT /trace and /traces` endpoints validate payload with ``@validate_openapi`` from kytos.core.
-- Add ``v1`` on API routes. 
 
 Changed
 =======
@@ -18,6 +17,7 @@ Changed
 - Add new case of `loop` when the outgoing interface is the same as the input interface.
 - Remove ``last_id`` and ``traces`` parameters
 - Remove ``GET /api/amlight/sdntrace_cp/trace/{trace_id}`` in ``openapi.yml``
+- Add ``v1`` on API routes. 
 
 Fixed
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 =====
 - Support "untagged" and "any" on EVCs.
 - `PUT /trace and /traces` endpoints validate payload with ``@validate_openapi`` from kytos.core.
+- Add ``v1`` on API routes. 
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ class Main(KytosNApp):
         self.automate.unschedule_ids()
         self.automate.sheduler_shutdown(wait=False)
 
-    @rest('/trace', methods=['PUT'])
+    @rest('/v1/trace', methods=['PUT'])
     @validate_openapi(spec)
     def trace(self, data):
         """Trace a path."""
@@ -69,7 +69,7 @@ class Main(KytosNApp):
         result = self.tracepath(entries, stored_flows)
         return jsonify(prepare_json(result))
 
-    @rest('/traces', methods=['PUT'])
+    @rest('/v1/traces', methods=['PUT'])
     @validate_openapi(spec)
     def get_traces(self, data):
         """For bulk requests."""

--- a/openapi.yml
+++ b/openapi.yml
@@ -4,7 +4,7 @@ info:
   version: '0.1'
   description: An OpenFlow Path Tracing on Control Plane
 paths:
-  /api/amlight/sdntrace_cp/trace:
+  /api/amlight/sdntrace_cp/v1/trace:
     put:
       summary: Trace a path
       description: Trace a path starting with the switch given with the parameters given. The trace is done entirely in control plane.
@@ -130,7 +130,7 @@ paths:
               schema:
                 type: string
                 example: Bad request
-  /api/amlight/sdntrace_cp/traces:
+  /api/amlight/sdntrace_cp/v1/traces:
     put:
       summary: Trace paths given switches
       description: Trace a path starting with each switch given in a list as parameter.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -22,7 +22,8 @@ class TestMain(TestCase):
 
         Set the server_name_url_url from amlight/sdntrace_cp
         """
-        self.server_name_url = "http://localhost:8181/api/amlight/sdntrace_cp"
+        self.server_name_url \
+            = "http://localhost:8181/api/amlight/sdntrace_cp/v1"
 
         # The decorator run_on_thread is patched, so methods that listen
         # for events do not run on threads while tested.
@@ -76,12 +77,12 @@ class TestMain(TestCase):
             (
                 {},
                 {"OPTIONS", "HEAD", "PUT"},
-                "/api/amlight/sdntrace_cp/trace/ ",
+                "/api/amlight/sdntrace_cp/v1/trace/ ",
             ),
             (
                 {},
                 {"OPTIONS", "HEAD", "PUT"},
-                "/api/amlight/sdntrace_cp/traces/ ",
+                "/api/amlight/sdntrace_cp/v1/traces/ ",
             ),
         ]
         urls = self.get_napp_urls(self.napp)


### PR DESCRIPTION
Closes #64 

### Summary

Add `v1` on `/trace` and `/traces`.

### Local Tests

I made sure that `GET /traces` and `GET /trace` work well:

```
curl -H 'Content-type: application/json' -X PUT http://127.0.0.1:8181/api/amlight/sdntrace_cp/v1/trace -d '{"trace": {"switch": {"dpid": "00:00:00:00:00:00:00:01","in_port": 1}}}'
```
```
{"result":[{"dpid":"00:00:00:00:00:00:00:01","port":1,"time":"2023-04-11 19:16:42.264349","type":"starting"},{"dpid":"00:00:00:00:00:00:00:02","out":null,"port":2,"time":"2023-04-11 19:16:42.264406","type":"incomplete"}]}
```

```
curl -H 'Content-type: application/json' -X PUT http://127.0.0.1:8181/api/amlight/sdntrace_cp/v1/traces -d '[{"trace": {"switch": {"dpid": "00:00:00:00:00:00:00:01","in_port": 1}}}]'
```
```
{"result":[[{"dpid":"00:00:00:00:00:00:00:01","port":1,"time":"2023-04-11 19:17:02.650791","type":"starting"},{"dpid":"00:00:00:00:00:00:00:02","out":null,"port":2,"time":"2023-04-11 19:17:02.650848","type":"incomplete"}]]}
``` 

### End-to-End Tests

Refactoring ...