### PR TITLE
feat: Remove automate in main

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,13 @@ Fixed
 - In ``PUT /trace`` and ``PUT /traces``, field ``switch``` is defined as required, as well as its parameters ``dpid``` and ``in_port``.
 - Check that an interface has been found with ``find_endpoint`` given ``switch`` and ``port`` at each ``trace_step``.
 
+Removed
+=======
+
+- Removed ``TRIGGER_SCHEDULE_TRACES``, ``TRIGGER_IMPORTANT_CIRCUITS`` and ``FIND_CIRCUITS_IN_FLOWS`` from settings.
+- Removed ``automate`` in ``main``.
+- Removed ``update_circuits`` functionality in ``main``. 
+
 [2022.3.1] - 2023-02-27
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -10,8 +10,6 @@ from datetime import datetime
 from flask import jsonify
 from kytos.core import KytosNApp, log, rest
 from kytos.core.helpers import load_spec, validate_openapi
-from napps.amlight.sdntrace_cp import settings
-from napps.amlight.sdntrace_cp.automate import Automate
 from napps.amlight.sdntrace_cp.utils import (convert_entries,
                                              convert_list_entries,
                                              find_endpoint, get_stored_flows,
@@ -36,10 +34,6 @@ class Main(KytosNApp):
         """
         log.info("Starting Kytos SDNTrace CP App!")
 
-        self.automate = Automate(self)
-        self.automate.schedule_traces()
-        self.automate.schedule_important_traces()
-
     def execute(self):
         """This method is executed right after the setup method execution.
 
@@ -54,8 +48,6 @@ class Main(KytosNApp):
 
         If you have some cleanup procedure, insert it here.
         """
-        self.automate.unschedule_ids()
-        self.automate.sheduler_shutdown(wait=False)
 
     @rest('/v1/trace', methods=['PUT'])
     @validate_openapi(spec)
@@ -184,12 +176,6 @@ class Main(KytosNApp):
                 'in_port': endpoint.port_number,
                 'out_port': port,
                 'entries': entries}
-
-    def update_circuits(self):
-        """Update the list of circuits after a flow change."""
-        # pylint: disable=unused-argument
-        if settings.FIND_CIRCUITS_IN_FLOWS:
-            self.automate.find_circuits()
 
     @classmethod
     def do_match(cls, flow, args):

--- a/settings.py
+++ b/settings.py
@@ -2,20 +2,6 @@
  sdntrace_cp settings
 """
 
-# Schedule automatic traces
-TRIGGER_SCHEDULE_TRACES = False
-SCHEDULE_TRIGGER = 'interval'
-SCHEDULE_ARGS = {'seconds': 120}
-
-TRIGGER_IMPORTANT_CIRCUITS = False
-IMPORTANT_CIRCUITS = []
-IMPORTANT_CIRCUITS_TRIGGER = 'interval'
-IMPORTANT_CIRCUITS_ARGS = {'seconds': 20}
-
-# Enable/Disables a routine that search for circuits upon receiving
-# amlight/flow_stats.flows_updated Kytos event
-FIND_CIRCUITS_IN_FLOWS = False
-
 SDNTRACE_URL = 'http://localhost:8181/api/amlight/sdntrace/trace'
 
 SLACK_CHANNEL = 'of_notifications'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -341,31 +341,6 @@ class TestMain(TestCase):
 
         self.assertFalse(result)
 
-    @patch("napps.amlight.sdntrace_cp.main.settings")
-    def test_update_circuits(self, mock_settings):
-        """Test update_circuits event listener with success."""
-        mock_settings.FIND_CIRCUITS_IN_FLOWS = True
-
-        self.napp.automate = MagicMock()
-        self.napp.automate.find_circuits = MagicMock()
-
-        self.napp.update_circuits()
-
-        self.napp.automate.find_circuits.assert_called_once()
-
-    @patch("napps.amlight.sdntrace_cp.main.settings")
-    def test_update_circuits__no_settings(self, mock_settings):
-        """Test update_circuits event listener without
-        settings option enabled."""
-        mock_settings.FIND_CIRCUITS_IN_FLOWS = False
-
-        self.napp.automate = MagicMock()
-        self.napp.automate.find_circuits = MagicMock()
-
-        self.napp.update_circuits()
-
-        self.napp.automate.find_circuits.assert_not_called()
-
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     def test_trace(self, mock_stored_flows):
         """Test trace rest call."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,12 +4,28 @@ from unittest.mock import patch, MagicMock
 
 from kytos.core.interface import Interface
 from kytos.lib.helpers import get_controller_mock, get_link_mock
-from napps.amlight.sdntrace_cp import utils
+from napps.amlight.sdntrace_cp import utils, settings
 
 
 # pylint: disable=too-many-public-methods, duplicate-code, protected-access
 class TestUtils(TestCase):
     """Test utils.py functions."""
+
+    @patch("requests.get")
+    def test_get_stored_flows(self, get_mock):
+        "Test get_stored_flows"
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"result": "ok"}
+        get_mock.return_value = response
+
+        api_url = f'{settings.FLOW_MANAGER_URL}/stored_flows/?state=installed'
+        result = utils.get_stored_flows()
+        get_mock.assert_called_with(
+                                    api_url,
+                                    timeout=30
+                                )
+        self.assertEqual(result['result'], "ok")
 
     def test_convert_list_entries(self):
         """Verify convert entries with a list of one example"""

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,9 @@
 """Utility functions to be used in this Napp"""
 
 import requests
-from kytos.core import KytosEvent
+from kytos.core import KytosEvent, log
 from napps.amlight.sdntrace_cp import settings
+from requests.exceptions import ConnectTimeout
 
 
 def get_stored_flows(dpids: list = None, state: str = "installed"):
@@ -16,7 +17,10 @@ def get_stored_flows(dpids: list = None, state: str = "installed"):
     if state:
         char = '&' if dpids else '/?'
         api_url += char+f'state={state}'
-    result = requests.get(api_url)
+    try:
+        result = requests.get(api_url, timeout=30)
+    except ConnectTimeout as exception:
+        log.error(f"Request has timed out: {exception}")
     flows_from_manager = result.json()
     return flows_from_manager
 


### PR DESCRIPTION
Closes #77 

### Summary

According to `main.py`, as well as `TRIGGER_SCHEDULE_TRACES`, `TRIGGER_IMPORTANT_CIRCUITS` and `FIND_CIRCUITS_IN_FLOWS` set to False, `automate.py` does not seem to be needed. So, this is to remove the dependency of `main.py` to `automate.py`.
Then, `automate.py` won't be used anymore and issue #39 is not needed.
Instead, a timeout has been added to the [requests from `stored_flows` to `flow_manager`]().

### Local Tests

Everything seems to continue working well.

```
2023-04-28 14:47:37,787 - INFO [kytos.napps.kytos/mef_eline] (mef_eline) EVC(6875c026f20a4b, epl) was deployed.
2023-04-28 14:47:37,788 - INFO [kytos.napps.kytos/mef_eline] (mef_eline) EVC(5b1147f173c84a, epl) enabled but inactive - redeploy
```

`/traces` call example:

```
[
    {
        "trace": {
            "switch": {
                "dpid": "00:00:00:00:00:00:00:01",
                "in_port": 1
            },
            "eth": {
      "         dl_vlan": 10
            }
        }
  }
]

{
    "result": [
        [
            {
                "dpid": "00:00:00:00:00:00:00:01",
                "port": 1,
                "time": "2023-04-28 14:42:30.554977",
                "type": "starting"
            },
            {
                "dpid": "00:00:00:00:00:00:00:02",
                "out": null,
                "port": 2,
                "time": "2023-04-28 14:42:30.555051",
                "type": "incomplete"
            }
        ]
    ]
}
``` 

### End-to-End Tests

N/A