### PR TITLE
Delete `incomplete` type.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Added
 
 Changed
 =======
-- Update ``tracepath`` to support two new trace types: ``loop`` and ``incomplete``. Both represent a failure, and ``incomplete`` type also replaces the empty list that was returned as a response in some cases. Other three types are ``starting`` for the first trace_step, ``intermediary`` for subsequent trace_steps (previously ``trace``), and ``last`` for the last trace_step representing successful trace.
+- Update ``tracepath`` to support the trace type: ``loop``. Other three types are ``starting`` for the first trace_step, ``intermediary`` for subsequent trace_steps (previously ``trace``), and ``last`` for the last trace_step representing successful trace.
 - Add new case of `loop` when the outgoing interface is the same as the input interface.
 - Remove ``last_id`` and ``traces`` parameters
 - Remove ``GET /api/amlight/sdntrace_cp/trace/{trace_id}`` in ``openapi.yml``

--- a/main.py
+++ b/main.py
@@ -126,8 +126,8 @@ class Main(KytosNApp):
                     trace_step['in']['type'] = 'last'
                     do_trace = False
             else:
-                trace_step['in']['type'] = 'incomplete'
-                do_trace = False
+                # Incomplete
+                break
             if 'out' in trace_step and trace_step['out']:
                 if self.check_loop_trace_step(trace_step, trace_result):
                     do_trace = False

--- a/openapi.yml
+++ b/openapi.yml
@@ -126,8 +126,8 @@ paths:
                           example: "2022-01-25 13:44:52.387021"
                         type:
                           type: string
-                          enum: ["starting", "intermediary", "last", "loop", "incomplete"]
-                          description: Type of the step. May be "starting", "intermediary", "last", and "loop" or "incomplete" for failure.
+                          enum: ["starting", "intermediary", "last", "loop"]
+                          description: Type of the step. May be "starting", "intermediary", "last", and "loop".
                           example: "intermediary"
                         vlan:
                           type: integer
@@ -268,8 +268,8 @@ paths:
                             example: "2022-01-25 13:44:52.387021"
                           type:
                             type: string
-                            enum: ["starting", "intermediary", "last", "loop", "incomplete"]
-                            description: Type of the step. May be "starting", "intermediary", "last", and "loop" or "incomplete" for failure.
+                            enum: ["starting", "intermediary", "last", "loop"]
+                            description: Type of the step. May be "starting", "intermediary", "last", and "loop".
                             example: "intermediary"
                           vlan:
                             type: integer

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -479,11 +479,7 @@ class TestMain:
         assert result[1][0]["vlan"] == 100
         assert result[1][0]["out"] is None
 
-        assert result[2][0]["dpid"] == "00:00:00:00:00:00:00:02"
-        assert result[2][0]["port"] == 2
-        assert result[2][0]["type"] == "incomplete"
-        assert result[2][0]["vlan"] == 100
-        assert result[2][0]["out"] is None
+        assert len(result[2]) == 0
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     async def test_traces_fail(self, mock_stored_flows, event_loop):
@@ -606,8 +602,8 @@ class TestMain:
         current_data = resp.json()
         result = current_data["result"]
         assert len(result) == 2
-        assert result[0][-1]['type'] == "incomplete"
-        assert result[1][-1]['type'] == "incomplete"
+        assert len(result[0]) == 0
+        assert len(result[1]) == 0
 
     @patch("napps.amlight.sdntrace_cp.main.get_stored_flows")
     async def test_get_traces_untagged(self, mock_stored_flows, event_loop):
@@ -766,8 +762,7 @@ class TestMain:
         result = current_data["result"]
         assert result[0][0]["type"] == "last"
         assert result[0][0]["out"] == {"port": 2}
-        assert result[1][0]["type"] == "incomplete"
-        assert result[1][0]["out"] is None
+        assert len(result[1]) == 0
 
         mock_stored_flows.return_value = {
             "00:00:00:00:00:00:00:01": [
@@ -784,8 +779,7 @@ class TestMain:
         result = current_data["result"]
         assert result[0][0]["type"] == "last"
         assert result[0][0]["out"] == {"port": 3}
-        assert result[1][0]["type"] == "incomplete"
-        assert result[1][0]["out"] is None
+        assert len(result[1]) == 0
 
     @pytest.mark.parametrize(
         "flow,args,match",


### PR DESCRIPTION
Closes #102 

### Summary

This update `tracepath` to remove `incomplete` type. There are 4 types now: `starting`, `intermediary`, `last` and `loop`. 
The only step_trace of traces with size 1 has the type `last`.

### Local Test

The step in issue #102  where followed:
```
kytos $> controller.napps[('kytos', 'mef_eline')].circuits                                                                         
Out[5]: 
{'166a91c6cd5941': EVC(166a91c6cd5941, pw_s3),
 '302ef6216c7642': EVC(302ef6216c7642, pw_s2),
 '9ebdbd584ee149': EVC(9ebdbd584ee149, evc-vlan-999)}
kytos $> cid = '166a91c6cd5941'

kytos $> from napps.kytos.mef_eline.models import EVCDeploy

kytos $> EVCDeploy.check_list_traces([controller.napps[('kytos', 'mef_eline')].circuits[cid]])

kytos $> EVCDeploy.check_list_traces([controller.napps[('kytos', 'mef_eline')].circuits[cid]])                                     

2023-07-26 16:32:44,198 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37080 - "GET /api/kytos/flow_manager/v2/stored_flows/?state=installed HTTP/1.1" 200
2023-07-26 16:32:44,206 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37066 - "PUT /api/amlight/sdntrace_cp/v1/traces HTTP/1.1" 200
Out[4]: {'166a91c6cd5941': True}

```
### End-to-end Test

In progress.