### PR TITLE
Check for `instructions` in `match_and_apply`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 =====
 - Support "untagged" and "any" on EVCs.
 - `PUT /trace and /traces` endpoints validate payload with ``@validate_openapi`` from kytos.core.
+- Support "instructions" to perform a match.
 
 Changed
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Support "instructions" to perform a match.
+
 [2023.1.0] - 2023-06-12
 ***********************
 
@@ -13,7 +17,6 @@ Added
 =====
 - Support ``"untagged"`` and ``"any"`` on EVCs.
 - ``PUT /trace and /traces`` endpoints validate payload with ``@validate_openapi``.
-- Support "instructions" to perform a match.
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -247,6 +247,7 @@ class Main(KytosNApp):
         return response
 
     # pylint: disable=redefined-outer-name
+    # pylint: disable=too-many-branches
     def match_and_apply(self, switch, args, stored_flows):
         # pylint: disable=bad-staticmethod-argument
         """Match flows and apply actions.
@@ -261,6 +262,10 @@ class Main(KytosNApp):
             return flow, args, port
         if 'actions' in flow['flow']:
             actions = flow['flow']['actions']
+        elif 'instructions' in flow['flow']:
+            for instruction in flow['flow']['instructions']:
+                if instruction['instruction_type'] == 'apply_actions':
+                    actions = instruction['actions']
         for action in actions:
             action_type = action['action_type']
             if action_type == 'output':


### PR DESCRIPTION
Closes #103 

### Summary

This is to support `instructions` in `sdntrace_cp` when performing a match.

### Local Test

Same example in issue:

```
{"result":[{"dpid":"00:00:00:00:00:00:00:01","port":1,"time":"2023-08-03 12:21:42.515496","type":"starting"},{"dpid":"00:00:00:00:00:00:00:02","port":2,"time":"2023-08-03 12:21:42.515556","type":"last","vlan":2,"out":{"port":1}}]}
```
### End-to-end Test

[See PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/254)