### PR TITLE
Support instruction type goto_table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 Added
 =====
 - Support "instructions" to perform a match.
+- Support instruction type `goto_table`.
 
 [2023.1.0] - 2023-06-12
 ***********************

--- a/main.py
+++ b/main.py
@@ -66,9 +66,9 @@ class Main(KytosNApp):
             raise HTTPException(424, "It couldn't get stored_flows") from exc
         try:
             result = self.tracepath(entries, stored_flows)
-        except ValueError as exception:
-            log.debug("tracepath error {exception}")
-            raise exception
+        except ValueError as exc:
+            log.debug("tracepath error {exc}")
+            raise HTTPException(409, str(exc)) from exc
         return JSONResponse(prepare_json(result))
 
     @rest('/v1/traces', methods=['PUT'])
@@ -85,9 +85,9 @@ class Main(KytosNApp):
         for entry in entries:
             try:
                 results.append(self.tracepath(entry, stored_flows))
-            except ValueError as exception:
-                log.debug("tracepath error {exception}")
-                raise exception
+            except ValueError as exc:
+                log.debug("tracepath error {exc}")
+                raise HTTPException(409, str(exc)) from exc
         return JSONResponse(prepare_json(results))
 
     def tracepath(self, entries, stored_flows):

--- a/main.py
+++ b/main.py
@@ -266,9 +266,11 @@ class Main(KytosNApp):
                         table_id = table_id_
                         goto_table = True
                     else:
-                        log.error(f"A packet can only been directed to a \
-                                  flow table number greather than {table_id}")
-                        raise ValueError('Wrong table_id')
+                        msg = f"Wrong table_id: \
+                            A packet can only been directed to a \
+                                flow table number greather than {table_id}"
+                        log.error(msg)
+                        raise ValueError(msg) from ValueError
         actions.extend(actions_)
         return flow, actions, goto_table, table_id
 
@@ -282,8 +284,11 @@ class Main(KytosNApp):
         port = None
         actions = []
         while goto_table:
-            flow, actions, goto_table, table_id = self.process_tables(
+            try:
+                flow, actions, goto_table, table_id = self.process_tables(
                     switch, table_id, args, stored_flows, actions)
+            except ValueError as exception:
+                raise exception
         if not flow or switch.ofp_version != '0x04':
             return flow, args, port
 

--- a/main.py
+++ b/main.py
@@ -67,7 +67,6 @@ class Main(KytosNApp):
         try:
             result = self.tracepath(entries, stored_flows)
         except ValueError as exc:
-            log.debug("tracepath error {exc}")
             raise HTTPException(409, str(exc)) from exc
         return JSONResponse(prepare_json(result))
 
@@ -86,7 +85,6 @@ class Main(KytosNApp):
             try:
                 results.append(self.tracepath(entry, stored_flows))
             except ValueError as exc:
-                log.debug("tracepath error {exc}")
                 raise HTTPException(409, str(exc)) from exc
         return JSONResponse(prepare_json(results))
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1191,9 +1191,6 @@ class TestMain:
             }
         }
         ]
-
-        resp = await self.api_client.put(self.traces_endpoint, json=payload)
-        assert resp.status_code == 200
-        current_data = resp.json()
-        result = current_data["result"]
-        assert len(result[0]) == 0
+        with pytest.raises(ValueError) as err:
+            await self.api_client.put(self.traces_endpoint, json=payload)
+        assert 'Wrong table_id' in str(err.value)


### PR DESCRIPTION
Closes #104 

### Summary

This is to support `goto_table` in `sdntrace_cp`.

### Local test

Send to s1:
```
{
    "force": false,
    "flows": [
        {
            "match": {
                "in_port": 1
            },
            "instructions": [
                {
                    "instruction_type": "goto_table",
                    "table_id": 1
                }
            ]
        },
        {
            "table_id": 1,
            "match": {
                "in_port": 1
            },
            "instructions": [
                {
                    "instruction_type": "apply_actions",
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 3
                        }
                    ]
                }
            ]
        }
    ]
}
```

Send to s2:
```
{
    "force": false,
    "flows": [
        {
            "match": {
                "in_port": 3
            },
            "instructions": [
                {
                    "instruction_type": "goto_table",
                    "table_id": 2
                }
            ]
        },
        {
            "table_id": 2,
            "match": {
                "in_port": 3
            },
            "instructions": [
                {
                    "instruction_type": "apply_actions",
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 2
                        }
                    ]
                }
            ]
        }
    ]
}
```
Topology:
```
h11 h11-eth0:s1-eth1
h12 h12-eth0:s1-eth2
h21 h21-eth0:s2-eth1
h22 h22-eth0:s2-eth2
s1 lo:  s1-eth1:h11-eth0 s1-eth2:h12-eth0 s1-eth3:s2-eth3
s2 lo:  s2-eth1:h21-eth0 s2-eth2:h22-eth0 s2-eth3:s1-eth3
```

Result:
```
sudo ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0xab00000000000001, duration=110.318s, table=0, n_packets=37, n_bytes=1554, send_flow_rem priority=50000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
 cookie=0xac00000000000001, duration=108.928s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0x0, duration=32.293s, table=0, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth1" actions=goto_table:1
 cookie=0x0, duration=110.273s, table=0, n_packets=41, n_bytes=4243, send_flow_rem priority=0 actions=CONTROLLER:65535
 cookie=0x0, duration=32.290s, table=1, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth1" actions=output:"s1-eth3"
```

```
sudo ovs-ofctl -O OpenFlow13 dump-flows s2
 cookie=0xab00000000000002, duration=119.369s, table=0, n_packets=40, n_bytes=1680, send_flow_rem priority=50000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
 cookie=0xac00000000000002, duration=117.923s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:01 actions=CONTROLLER:65535
 cookie=0x0, duration=16.511s, table=0, n_packets=1, n_bytes=70, send_flow_rem in_port="s2-eth3" actions=goto_table:2
 cookie=0x0, duration=119.354s, table=0, n_packets=37, n_bytes=3724, send_flow_rem priority=0 actions=CONTROLLER:65535
 cookie=0x0, duration=16.499s, table=2, n_packets=1, n_bytes=70, send_flow_rem in_port="s2-eth3" actions=output:"s2-eth2"
```
```
/sdntrace_cp/v1/trace
{
  "trace": {
    "switch": {
      "dpid": "00:00:00:00:00:00:00:01",
      "in_port": 1
    }
  }
}
```

```
{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 1,
            "time": "2023-09-11 15:27:42.440712",
            "type": "starting"
        },
        {
            "dpid": "00:00:00:00:00:00:00:02",
            "port": 3,
            "time": "2023-09-11 15:27:42.440806",
            "type": "last",
            "out": {
                "port": 2
            }
        }
    ]
}
```

### End-to-end test

Progress ...