### PR TITLE
Migration to Vue3: additional change to make InfoPanel display maximized as before

### DIFF
--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -159,6 +159,7 @@ module.exports = {
                     "component": 'amlight-sdntrace_cp-k-info-panel-show_trace_results',
                     "content": this.trace,
                     "icon": "search-location",
+                    "maximized": true,
                     "title": "Trace",
                     "subtitle": "by amlight/sdntrace_cp"
                     }


### PR DESCRIPTION
Related to https://github.com/kytos-ng/ui/issues/35

### Summary

This PR should sit on top of https://github.com/kytos-ng/sdntrace_cp/pull/116 and it makes the InfoPanel be displayed maximized as it used to be before vue3 migration