### PR TITLE
Made changes for vue3sfcloader compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the sdntrace_cp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- Updated watchers
+
+Added
+=====
+- Inputs used for display only were disabled
+
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/ui/k-info-panel/show_trace_results.kytos
+++ b/ui/k-info-panel/show_trace_results.kytos
@@ -62,8 +62,11 @@ module.exports = {
     } 
   },
   watch: {
-    content: function() {
-      this.get_data();
+    content: {
+      handler: function() {
+        this.get_data();
+      },
+      deep: true
     }
   },
   created() {

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -14,7 +14,7 @@
                       @blur="onblur_dpids"
                       >{{ dpid }}</k-input-auto>
 
-            <k-input class="k-input interface-label" v-model:value="dpid_display" icon="none"
+            <k-input class="k-input interface-label" v-model:value="dpid_display" icon="none" :isDisabled="true"
                       >{{ dpid_display }}</k-input>
 
             <k-input-auto id="in_port" v-model:value="in_port"
@@ -25,7 +25,7 @@
                       @blur="onblur_ports"
                       >{{ in_port }}</k-input-auto>
 
-            <k-input class="k-input interface-label" v-model:value="port_name" icon="none"
+            <k-input class="k-input interface-label" v-model:value="port_name" icon="none" :isDisabled="true"
                       >{{ port_name }}</k-input>
 
           </k-accordion-item>


### PR DESCRIPTION
Closes #128 

### Summary

The watchers needed to be updated.
There were some k-inputs that were only being used for display data, so I disabled the ability to write text into them.

### Local Tests

After applying the changes I no longer got the errors.
