### PR TITLE
Added customClass to k-inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changed
 Added
 =====
 - Inputs used for display only were disabled
+- k-inputs now use customClass prop to add CSS classes
 
 [2024.1.0] - 2024-07-23
 ***********************

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -14,7 +14,7 @@
                       @blur="onblur_dpids"
                       >{{ dpid }}</k-input-auto>
 
-            <k-input class="k-input interface-label" v-model:value="dpid_display" icon="none" :isDisabled="true"
+            <k-input customClass="k-input interface-label" v-model:value="dpid_display" icon="none" :isDisabled="true"
                       >{{ dpid_display }}</k-input>
 
             <k-input-auto id="in_port" v-model:value="in_port"
@@ -25,7 +25,7 @@
                       @blur="onblur_ports"
                       >{{ in_port }}</k-input-auto>
 
-            <k-input class="k-input interface-label" v-model:value="port_name" icon="none" :isDisabled="true"
+            <k-input customClass="k-input interface-label" v-model:value="port_name" icon="none" :isDisabled="true"
                       >{{ port_name }}</k-input>
 
           </k-accordion-item>


### PR DESCRIPTION
Closes #127 

### Summary

K-inputs now use the new customClass prop to add their CSS classes instead of just using class, so that they are compatible with the vue3-sfc-loader.
For these changes to work, you need the latest custom class additions from the main UI repo:
https://github.com/kytos-ng/ui/pull/118#issue-2727981658

### Local Tests

I ran it on my local environment and no errors were produced.

